### PR TITLE
Multiple worlds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,72 @@
 # Changelog
 
+## 0.5.0
+
+Add support for multiple parallell world instances
+
+**Breaking changes:**
+
+Configuration is now supplied when adding the plugin
+
+```rust
+// First declare a config struct. It needs to derive `Resource`, `Clone` and `Default`
+#[derive(Resource, Clone, Default)]
+struct MyWorld;
+
+// Then implement the `VoxelWorldConfig` trait for it:
+impl VoxelWorldConfig for MyWorld {
+    // All the trait methods have defaults, so you only need to add the ones you want to alter
+    fn spawning_distance(&self) -> u32 {
+       15
+    }
+}
+```
+
+Then when adding the plugin:
+
+```rust
+.add_plugins(VoxelWorldPlugin::with_config(MyWorld))
+```
+
+If you don't want to change any default config, you can simply do this:
+
+```rust
+.add_plugins(VoxelWorldPlugin::default())
+```
+
+Adding multiple worlds follows the same pattern. Just create different configuration structs and add a `VoxelWorldPlugin` for each.
+
+```rust
+.add_plugins(VoxelWorldPlugin::with_config(MyOtherWorld))
+```
+
+Each world instance can have it's own configuration and will keep track of it's own set of voxel data and chunks.
+
+### The `VoxelWorld` system param now needs a type parameter to specify which world instance you want to select
+
+The configuration struct adds the config values and its type also acts as a marker for the world instance.
+
+```rust
+fn my_system(
+  my_voxel_world: VoxelWorld<MyWorld>,
+  my_other_voxel_world: VoxelWorld<MyOtherWorld>
+) {
+  // Set a voxel in `my_voxel_world`
+  my_voxel_world.set_voxel(pos, WorldVoxel::Solid(voxel_type))
+
+  // Set a voxel in `my_other_voxel_world`
+  my_other_voxel_world.set_voxel(pos, WorldVoxel::Solid(voxel_type))
+}
+```
+
+If you initialized the plugin with `::default()`, you still need to explicitly specify the instance as `DefaultWorld`:
+
+```rust
+fn my_system(voxel_world: VoxelWorld<DefaultWorld>) { ... }
+```
+
+The `VoxelWorldRaycast` system param now also requires the same config type paramter as described above.
+
 ## 0.4.0
 
 - Update to Bevy 0.13

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Create a configuration struct for your world:
 struct MyWorld;
 
 impl VoxelWorldConfig for MyWorld {
-    // All options have defaults, so you only need to add the ones you want to modify. For a full list, see src/configuration.rs
+    // All options have defaults, so you only need to add the ones you want to modify.
+    // For a full list, see src/configuration.rs
     fn spawning_distance(&self) -> u32 {
         25
     }
@@ -44,8 +45,8 @@ Then add the plugin with your config:
 
 The config struct does two things:
 
-- It supplies the configuration value
-- Its type also acts as a world instance identifier. This means that you can create multiple worlds by adding multiple instances of the plugin as long as each instance has a unique configuration struct.
+- It supplies the configuration values
+- Its type also acts as a world instance identifier. This means that you can create multiple worlds by adding multiple instances of the plugin as long as each instance has a unique configuration struct. [Here's an example of two worlds using different materials](https://github.com/splashdust/bevy_voxel_world/blob/main/examples/multiple_worlds.rs)
 
 ## Accessing the world
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ See the [textures example](https://github.com/splashdust/bevy_voxel_world/blob/m
 
 ### Custom shader support
 
-If you need to customize materials futher, you can use `VoxelWorldMaterialPlugin` to register your own Bevy material. This allows you to use your own custom shader with `bevy_voxel_world`. See [this example](https://github.com/splashdust/bevy_voxel_world/blob/main/examples/custom_material.rs) for more details.
+If you need to customize materials futher, you can use `.with_material(MyCustomVoxelMaterial)`, when adding the plugin, to register your own Bevy material. This allows you to use your own custom shader with `bevy_voxel_world`. See [this example](https://github.com/splashdust/bevy_voxel_world/blob/main/examples/custom_material.rs) for more details.
 
 ## Ray casting
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ If you need to customize materials futher, you can use `.with_material(MyCustomV
 To find a voxel location in the world from a pixel location on the screen, for example the mouse location, you can ray cast into the voxel world.
 
 ```rust
-fn update_cursor_cube(
+fn do_something_with_mouse_voxel_pos(
     voxel_world_raycast: VoxelWorldRaycast<MyWorld>,
     camera_info: Query<(&Camera, &GlobalTransform), With<VoxelWorldCamera>>,
     mut cursor_evr: EventReader<CursorMoved>,

--- a/examples/bombs.rs
+++ b/examples/bombs.rs
@@ -3,10 +3,17 @@ use bevy_voxel_world::prelude::*;
 use noise::{HybridMulti, NoiseFn, Perlin};
 use std::time::Duration;
 
+#[derive(Clone, Default)]
+struct MainWorld;
+
+#[derive(Clone, Default)]
+struct SecondWorld;
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(VoxelWorldPlugin::default())
+        .add_plugins(VoxelWorldPlugin::<MainWorld>::default())
+        .add_plugins(VoxelWorldPlugin::<SecondWorld>::default())
         .add_systems(Startup, setup)
         .add_systems(Update, move_camera)
         .add_systems(Update, explosion)
@@ -19,7 +26,7 @@ struct ExplosionTimeout {
 }
 
 fn setup(mut commands: Commands) {
-    commands.insert_resource(VoxelWorldConfiguration {
+    commands.insert_resource(VoxelWorldConfiguration::<MainWorld> {
         // This is the spawn distance (in 32 meter chunks), centered around the camera.
         spawning_distance: 15,
 
@@ -27,6 +34,17 @@ fn setup(mut commands: Commands) {
         // This may seem a bit convoluted, but it allows us to capture data in a sendable closure to be sent off
         // to a differrent thread for the meshing process. A new closure is fetched for each chunk.
         voxel_lookup_delegate: Box::new(move |_chunk_pos| get_voxel_fn()), // `get_voxel_fn` is defined below
+        ..Default::default()
+    });
+
+    commands.insert_resource(VoxelWorldConfiguration::<SecondWorld> {
+        // This is the spawn distance (in 32 meter chunks), centered around the camera.
+        spawning_distance: 10,
+
+        // Here we supply a closure that returns another closure that returns a voxel value for a given position.
+        // This may seem a bit convoluted, but it allows us to capture data in a sendable closure to be sent off
+        // to a differrent thread for the meshing process. A new closure is fetched for each chunk.
+        voxel_lookup_delegate: Box::new(move |_chunk_pos| get_voxel_fn_2()), // `get_voxel_fn` is defined below
         ..Default::default()
     });
 
@@ -63,7 +81,7 @@ fn setup(mut commands: Commands) {
     // Ambient light, same color as sun
     commands.insert_resource(AmbientLight {
         color: Color::rgb(0.98, 0.95, 0.82),
-        brightness: 0.3,
+        brightness: 100.0,
     });
 }
 
@@ -92,7 +110,7 @@ fn get_voxel_fn() -> Box<dyn FnMut(IVec3) -> WorldVoxel + Send + Sync> {
         let sample = match cache.get(&(pos.x, pos.z)) {
             Some(sample) => *sample,
             None => {
-                let sample = noise.get([x / 800.0, z / 800.0]) * 50.0;
+                let sample = noise.get([x / 800.0, z / 800.0]) * 25.0;
                 cache.insert((pos.x, pos.z), sample);
                 sample
             }
@@ -114,13 +132,60 @@ fn get_voxel_fn() -> Box<dyn FnMut(IVec3) -> WorldVoxel + Send + Sync> {
     })
 }
 
+fn get_voxel_fn_2() -> Box<dyn FnMut(IVec3) -> WorldVoxel + Send + Sync> {
+    // Set up some noise to use as the terrain height map
+    let mut noise = HybridMulti::<Perlin>::new(1234);
+    noise.octaves = 4;
+    noise.frequency = 1.0;
+    noise.lacunarity = 2.2;
+    noise.persistence = 0.5;
+
+    // We use this to cache the noise value for each y column so we only need
+    // to calculate it once per x/z coordinate
+    let mut cache = HashMap::<(i32, i32), f64>::new();
+
+    // Then we return this boxed closure that captures the noise and the cache
+    // This will get sent off to a separate thread for meshing by bevy_voxel_world
+    Box::new(move |pos: IVec3| {
+        // Sea level
+        if pos.y < 1 {
+            return WorldVoxel::Solid(3);
+        }
+
+        let [x, y, z] = pos.as_dvec3().to_array();
+
+        let sample = match cache.get(&(pos.x, pos.z)) {
+            Some(sample) => *sample,
+            None => {
+                let sample = noise.get([x / 400.0, z / 400.0]) * 50.0;
+                cache.insert((pos.x, pos.z), sample);
+                sample
+            }
+        };
+
+        // If y is less than the noise sample, we will set the voxel to solid
+        let is_surface = y < sample;
+        let is_sub_surface = y < sample - 1.0;
+
+        if is_surface && !is_sub_surface {
+            // Solid voxel of material type 0
+            WorldVoxel::Solid(1)
+        } else if is_sub_surface {
+            // Solid voxel of material type 1
+            WorldVoxel::Solid(0)
+        } else {
+            WorldVoxel::Air
+        }
+    })
+}
+
 fn move_camera(time: Res<Time>, mut cam_transform: Query<&mut Transform, With<VoxelWorldCamera>>) {
     cam_transform.single_mut().translation.x += time.delta_seconds() * 7.0;
     cam_transform.single_mut().translation.z += time.delta_seconds() * 12.0;
 }
 
 fn explosion(
-    mut voxel_world: VoxelWorld,
+    mut voxel_world: VoxelWorld<MainWorld>,
     camera: Query<&Transform, With<VoxelWorldCamera>>,
     mut timeout: Query<&mut ExplosionTimeout>,
     time: Res<Time>,

--- a/examples/custom_material.rs
+++ b/examples/custom_material.rs
@@ -41,6 +41,8 @@ fn main() {
         .add_plugins(MaterialPlugin::<CustomVoxelMaterial>::default())
         //
         // Then we can tell `bevy_voxel_world` to use that material when adding the plugin.
+        // bevy_voxel_world will add the material as an asset, so you can query for it later using
+        // `Res<Assets<CustomVoxelMaterial>>`.
         .add_plugins(
             VoxelWorldPlugin::with_config(MyMainWorld)
                 .with_material(CustomVoxelMaterial { _unused: 0 }),

--- a/examples/multiple_worlds.rs
+++ b/examples/multiple_worlds.rs
@@ -1,0 +1,186 @@
+use std::sync::Arc;
+
+use bevy::{
+    pbr::{CascadeShadowConfigBuilder, MaterialPipeline, MaterialPipelineKey},
+    prelude::*,
+    render::{
+        mesh::MeshVertexBufferLayout,
+        render_resource::{
+            AsBindGroup, RenderPipelineDescriptor, ShaderRef, SpecializedMeshPipelineError,
+        },
+    },
+    utils::HashMap,
+};
+use bevy_voxel_world::{
+    prelude::*,
+    rendering::{vertex_layout, VOXEL_TEXTURE_SHADER_HANDLE},
+};
+use noise::{HybridMulti, NoiseFn, Perlin};
+
+const RED: u8 = 0;
+const GREEN: u8 = 1;
+const BLUE: u8 = 2;
+
+// This is the main world configuration. In this example, the main world is the procedural terrain.
+#[derive(Resource, Clone, Default)]
+struct MainWorld;
+
+impl VoxelWorldConfig for MainWorld {
+    fn spawning_distance(&self) -> u32 {
+        10
+    }
+
+    fn voxel_lookup_delegate(&self) -> VoxelLookupDelegate {
+        Box::new(move |_chunk_pos| get_voxel_fn())
+    }
+}
+
+// This is the second world configuration. In this example, the second world is using a custom material.
+#[derive(Resource, Clone, Default)]
+struct SecondWorld;
+
+impl VoxelWorldConfig for SecondWorld {
+    fn texture_index_mapper(&self) -> Arc<dyn Fn(u8) -> [u32; 3] + Send + Sync> {
+        Arc::new(|vox_mat: u8| match vox_mat {
+            RED => [1, 1, 1],
+            GREEN => [2, 2, 2],
+            BLUE | _ => [3, 3, 3],
+        })
+    }
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(MaterialPlugin::<CustomVoxelMaterial>::default())
+        .add_plugins(VoxelWorldPlugin::with_config(MainWorld)) // Add the main world
+        .add_plugins(
+            // Add the second world with a custom material
+            VoxelWorldPlugin::with_config(SecondWorld)
+                .with_material(CustomVoxelMaterial { _unused: 0 }),
+        )
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(mut commands: Commands, mut second_world: VoxelWorld<SecondWorld>) {
+    // --- Just scene setup below ---
+
+    // camera
+    commands.spawn((
+        Camera3dBundle {
+            transform: Transform::from_xyz(-10.0, 10.0, -10.0).looking_at(Vec3::Y * 4.0, Vec3::Y),
+            ..default()
+        },
+        // This tells bevy_voxel_world tos use this cameras transform to calculate spawning area
+        VoxelWorldCamera,
+    ));
+
+    // Sun
+    let cascade_shadow_config = CascadeShadowConfigBuilder { ..default() }.build();
+    commands.spawn(DirectionalLightBundle {
+        directional_light: DirectionalLight {
+            color: Color::rgb(0.98, 0.95, 0.82),
+            shadows_enabled: true,
+            ..default()
+        },
+        transform: Transform::from_xyz(0.0, 0.0, 0.0)
+            .looking_at(Vec3::new(-0.15, -0.1, 0.15), Vec3::Y),
+        cascade_shadow_config,
+        ..default()
+    });
+
+    // Ambient light, same color as sun
+    commands.insert_resource(AmbientLight {
+        color: Color::rgb(0.98, 0.95, 0.82),
+        brightness: 100.0,
+    });
+
+    // Set some voxels in the second world
+    second_world.set_voxel(IVec3::new(0, 2, 0), WorldVoxel::Solid(RED));
+    second_world.set_voxel(IVec3::new(1, 2, 0), WorldVoxel::Solid(RED));
+    second_world.set_voxel(IVec3::new(0, 2, 1), WorldVoxel::Solid(RED));
+    second_world.set_voxel(IVec3::new(0, 2, -1), WorldVoxel::Solid(RED));
+    second_world.set_voxel(IVec3::new(-1, 2, 0), WorldVoxel::Solid(GREEN));
+    second_world.set_voxel(IVec3::new(-2, 2, 0), WorldVoxel::Solid(GREEN));
+    second_world.set_voxel(IVec3::new(-1, 3, 0), WorldVoxel::Solid(RED));
+    second_world.set_voxel(IVec3::new(-2, 3, 0), WorldVoxel::Solid(RED));
+    second_world.set_voxel(IVec3::new(0, 3, 0), WorldVoxel::Solid(RED));
+}
+
+fn get_voxel_fn() -> Box<dyn FnMut(IVec3) -> WorldVoxel + Send + Sync> {
+    // Set up some noise to use as the terrain height map
+    let mut noise = HybridMulti::<Perlin>::new(1234);
+    noise.octaves = 4;
+    noise.frequency = 1.0;
+    noise.lacunarity = 2.2;
+    noise.persistence = 0.5;
+
+    // We use this to cache the noise value for each y column so we only need
+    // to calculate it once per x/z coordinate
+    let mut cache = HashMap::<(i32, i32), f64>::new();
+
+    // Then we return this boxed closure that captures the noise and the cache
+    // This will get sent off to a separate thread for meshing by bevy_voxel_world
+    Box::new(move |pos: IVec3| {
+        // Sea level
+        if pos.y < 1 {
+            return WorldVoxel::Solid(3);
+        }
+
+        let [x, y, z] = pos.as_dvec3().to_array();
+
+        let sample = match cache.get(&(pos.x, pos.z)) {
+            Some(sample) => *sample,
+            None => {
+                let sample = noise.get([x / 700.0, z / 700.0]) * 5.0;
+                cache.insert((pos.x, pos.z), sample);
+                sample
+            }
+        };
+
+        // If y is less than the noise sample, we will set the voxel to solid
+        let is_surface = y < sample;
+        let is_sub_surface = y < sample - 1.0;
+
+        if is_surface && !is_sub_surface {
+            // Solid voxel of material type 0
+            WorldVoxel::Solid(0)
+        } else if is_sub_surface {
+            // Solid voxel of material type 1
+            WorldVoxel::Solid(1)
+        } else {
+            WorldVoxel::Air
+        }
+    })
+}
+
+// This is the custom material. You can set this up like any other material in Bevy.
+#[derive(Asset, TypePath, AsBindGroup, Debug, Clone)]
+struct CustomVoxelMaterial {
+    // We're not using any uniforms in this example
+    _unused: u32,
+}
+
+impl Material for CustomVoxelMaterial {
+    fn vertex_shader() -> ShaderRef {
+        // You can use the default shader from bevy_voxel_world for the vertex shader for simplicity
+        VOXEL_TEXTURE_SHADER_HANDLE.into()
+    }
+
+    fn fragment_shader() -> ShaderRef {
+        "custom_material.wgsl".into()
+    }
+
+    fn specialize(
+        _pipeline: &MaterialPipeline<Self>,
+        descriptor: &mut RenderPipelineDescriptor,
+        layout: &MeshVertexBufferLayout,
+        _key: MaterialPipelineKey<Self>,
+    ) -> Result<(), SpecializedMeshPipelineError> {
+        // Use `vertex_layout()` from `bevy_voxel_world` to get the correct vertex layout
+        let vertex_layout = layout.get_layout(&vertex_layout())?;
+        descriptor.vertex.buffers = vec![vertex_layout];
+        Ok(())
+    }
+}

--- a/examples/noise_terrain.rs
+++ b/examples/noise_terrain.rs
@@ -2,29 +2,29 @@ use bevy::{pbr::CascadeShadowConfigBuilder, prelude::*, utils::HashMap};
 use bevy_voxel_world::prelude::*;
 use noise::{HybridMulti, NoiseFn, Perlin};
 
+#[derive(Resource, Clone, Default)]
+struct MainWorld;
+
+impl VoxelWorldConfig for MainWorld {
+    fn spawning_distance(&self) -> u32 {
+        25
+    }
+
+    fn voxel_lookup_delegate(&self) -> VoxelLookupDelegate {
+        Box::new(move |_chunk_pos| get_voxel_fn())
+    }
+}
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(VoxelWorldPlugin::default())
+        .add_plugins(VoxelWorldPlugin::with_config(MainWorld))
         .add_systems(Startup, setup)
         .add_systems(Update, move_camera)
         .run();
 }
 
 fn setup(mut commands: Commands) {
-    commands.insert_resource(VoxelWorldConfiguration {
-        // This is the spawn distance (in 32 meter chunks), centered around the camera.
-        spawning_distance: 25,
-
-        // Here we supply a closure that returns another closure that returns a voxel value for a given position.
-        // This may seem a bit convoluted, but it allows us to capture data in a sendable closure to be sent off
-        // to a differrent thread for the meshing process. A new closure is fetched for each chunk.
-        voxel_lookup_delegate: Box::new(move |_chunk_pos| get_voxel_fn()), // `get_voxel_fn` is defined below
-        ..Default::default()
-    });
-
-    // --- Just scene setup below ---
-
     // camera
     commands.spawn((
         Camera3dBundle {
@@ -52,7 +52,7 @@ fn setup(mut commands: Commands) {
     // Ambient light, same color as sun
     commands.insert_resource(AmbientLight {
         color: Color::rgb(0.98, 0.95, 0.82),
-        brightness: 0.3,
+        brightness: 100.0,
     });
 }
 

--- a/examples/ray_cast.rs
+++ b/examples/ray_cast.rs
@@ -48,7 +48,9 @@ fn setup(
     // Cursor cube
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+            mesh: meshes.add(Mesh::from(Cuboid {
+                half_size: Vec3::splat(0.5),
+            })),
             material: materials.add(Color::rgba_u8(124, 144, 255, 128)),
             transform: Transform::from_xyz(0.0, -10.0, 0.0),
             ..default()

--- a/examples/set_voxel.rs
+++ b/examples/set_voxel.rs
@@ -25,11 +25,11 @@ fn setup(mut commands: Commands) {
     // Ambient light
     commands.insert_resource(AmbientLight {
         color: Color::rgb(0.98, 0.95, 0.82),
-        brightness: 1.0,
+        brightness: 1000.0,
     });
 }
 
-fn set_solid_voxel(mut voxel_world: VoxelWorld) {
+fn set_solid_voxel(mut voxel_world: VoxelWorld<DefaultWorld>) {
     // Generate some random values
     let size = 10;
     let mut rng = rand::thread_rng();

--- a/examples/textures.rs
+++ b/examples/textures.rs
@@ -7,31 +7,35 @@ const SNOWY_BRICK: u8 = 0;
 const FULL_BRICK: u8 = 1;
 const GRASS: u8 = 2;
 
+#[derive(Resource, Clone, Default)]
+struct MyMainWorld;
+
+impl VoxelWorldConfig for MyMainWorld {
+    fn texture_index_mapper(&self) -> Arc<dyn Fn(u8) -> [u32; 3] + Send + Sync> {
+        Arc::new(|vox_mat: u8| match vox_mat {
+            SNOWY_BRICK => [0, 1, 2],
+            FULL_BRICK => [2, 2, 2],
+            GRASS | _ => [3, 3, 3],
+        })
+    }
+}
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         // We can specify a custom texture when initializing the plugin.
         // This should just be a path to an image in your assets folder.
-        .add_plugins(VoxelWorldPlugin::default().with_voxel_texture(
-            "example_voxel_texture.png",
-            4, // number of indexes in the texture
-        ))
+        .add_plugins(
+            VoxelWorldPlugin::with_config(MyMainWorld).with_voxel_texture(
+                "example_voxel_texture.png",
+                4, // number of indexes in the texture
+            ),
+        )
         .add_systems(Startup, (setup, create_voxel_scene).chain())
         .run();
 }
 
 fn setup(mut commands: Commands) {
-    commands.insert_resource(VoxelWorldConfiguration {
-        // To specify how the texture map to different kind of voxels we add this mapping callback
-        // For each material type, we specify the texture coordinates for the top, side and bottom faces.
-        texture_index_mapper: Arc::new(|vox_mat: u8| match vox_mat {
-            SNOWY_BRICK => [0, 1, 2],
-            FULL_BRICK => [2, 2, 2],
-            GRASS | _ => [3, 3, 3],
-        }),
-        ..Default::default()
-    });
-
     // Camera
     commands.spawn((
         Camera3dBundle {
@@ -53,7 +57,7 @@ fn setup(mut commands: Commands) {
     });
 }
 
-fn create_voxel_scene(mut voxel_world: VoxelWorld) {
+fn create_voxel_scene(mut voxel_world: VoxelWorld<MyMainWorld>) {
     // Then we can use the `u8` consts to specify the type of voxel
 
     // 20 by 20 floor

--- a/examples/textures.rs
+++ b/examples/textures.rs
@@ -18,6 +18,10 @@ impl VoxelWorldConfig for MyMainWorld {
             GRASS | _ => [3, 3, 3],
         })
     }
+
+    fn voxel_texture(&self) -> Option<(String, u32)> {
+        Some(("example_voxel_texture.png".into(), 4))
+    }
 }
 
 fn main() {
@@ -25,12 +29,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         // We can specify a custom texture when initializing the plugin.
         // This should just be a path to an image in your assets folder.
-        .add_plugins(
-            VoxelWorldPlugin::with_config(MyMainWorld).with_voxel_texture(
-                "example_voxel_texture.png",
-                4, // number of indexes in the texture
-            ),
-        )
+        .add_plugins(VoxelWorldPlugin::with_config(MyMainWorld))
         .add_systems(Startup, (setup, create_voxel_scene).chain())
         .run();
 }

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -23,13 +23,13 @@ pub(crate) type VoxelArray = [WorldVoxel; PaddedChunkShape::SIZE as usize];
 
 #[derive(Component)]
 #[component(storage = "SparseSet")]
-pub(crate) struct ChunkThread<I: Clone>(pub Task<ChunkTask<I>>, pub IVec3, PhantomData<I>);
+pub(crate) struct ChunkThread<C>(pub Task<ChunkTask<C>>, pub IVec3, PhantomData<C>);
 
-impl<I> ChunkThread<I>
+impl<C> ChunkThread<C>
 where
-    I: Clone + Send + Sync + 'static,
+    C: Send + Sync + 'static,
 {
-    pub fn new(task: Task<ChunkTask<I>>, pos: IVec3) -> Self {
+    pub fn new(task: Task<ChunkTask<C>>, pos: IVec3) -> Self {
         Self(task, pos, PhantomData)
     }
 }
@@ -131,13 +131,13 @@ impl Default for ChunkData {
 
 /// A marker component for chunks, with some helpful data
 #[derive(Component, Clone)]
-pub struct Chunk<I> {
+pub struct Chunk<C> {
     pub position: IVec3,
     pub entity: Entity,
-    _marker: PhantomData<I>,
+    _marker: PhantomData<C>,
 }
 
-impl<I> Chunk<I> {
+impl<C> Chunk<C> {
     pub fn new(position: IVec3, entity: Entity) -> Self {
         Self {
             position,
@@ -146,7 +146,7 @@ impl<I> Chunk<I> {
         }
     }
 
-    pub fn from(chunk: &Chunk<I>) -> Self {
+    pub fn from(chunk: &Chunk<C>) -> Self {
         Self {
             position: chunk.position,
             entity: chunk.entity,
@@ -163,16 +163,16 @@ impl<I> Chunk<I> {
 
 /// Holds all data needed to generate and mesh a chunk
 #[derive(Component)]
-pub(crate) struct ChunkTask<I: Clone> {
+pub(crate) struct ChunkTask<C> {
     pub position: IVec3,
     pub chunk_data: ChunkData,
-    pub modified_voxels: ModifiedVoxels<I>,
+    pub modified_voxels: ModifiedVoxels<C>,
     pub mesh: Option<Mesh>,
-    _marker: PhantomData<I>,
+    _marker: PhantomData<C>,
 }
 
-impl<I: Clone + Send + Sync + 'static> ChunkTask<I> {
-    pub fn new(entity: Entity, position: IVec3, modified_voxels: ModifiedVoxels<I>) -> Self {
+impl<C: Send + Sync + 'static> ChunkTask<C> {
+    pub fn new(entity: Entity, position: IVec3, modified_voxels: ModifiedVoxels<C>) -> Self {
         Self {
             position,
             chunk_data: ChunkData::with_entity(entity),

--- a/src/chunk_map.rs
+++ b/src/chunk_map.rs
@@ -14,12 +14,12 @@ use crate::{
 /// The chunks also exist as entities that can be queried in the ECS,
 /// but having this map in addition allows for faster spatial lookups
 #[derive(Resource)]
-pub struct ChunkMap<I> {
+pub struct ChunkMap<C> {
     map: Arc<RwLock<HashMap<IVec3, chunk::ChunkData>>>,
-    _marker: PhantomData<I>,
+    _marker: PhantomData<C>,
 }
 
-impl<I: Send + Sync + 'static> ChunkMap<I> {
+impl<C: Send + Sync + 'static> ChunkMap<C> {
     pub fn get(
         position: &IVec3,
         read_lock: &RwLockReadGuard<HashMap<IVec3, chunk::ChunkData>>,
@@ -44,9 +44,9 @@ impl<I: Send + Sync + 'static> ChunkMap<I> {
 
     pub(crate) fn apply_buffers(
         &self,
-        insert_buffer: &mut ChunkMapInsertBuffer<I>,
-        update_buffer: &mut ChunkMapUpdateBuffer<I>,
-        remove_buffer: &mut ChunkMapRemoveBuffer<I>,
+        insert_buffer: &mut ChunkMapInsertBuffer<C>,
+        update_buffer: &mut ChunkMapUpdateBuffer<C>,
+        remove_buffer: &mut ChunkMapRemoveBuffer<C>,
         ev_chunk_will_spawn: &mut EventWriter<ChunkWillSpawn>,
     ) {
         if insert_buffer.is_empty() && update_buffer.is_empty() && remove_buffer.is_empty() {
@@ -85,7 +85,7 @@ impl<I: Send + Sync + 'static> ChunkMap<I> {
     }
 }
 
-impl<I> Default for ChunkMap<I> {
+impl<C> Default for ChunkMap<C> {
     fn default() -> Self {
         Self {
             map: Arc::new(RwLock::new(HashMap::with_capacity(1000))),
@@ -95,13 +95,13 @@ impl<I> Default for ChunkMap<I> {
 }
 
 #[derive(Resource, Deref, DerefMut, Default, Debug)]
-pub(crate) struct ChunkMapInsertBuffer<I>(#[deref] Vec<(IVec3, chunk::ChunkData)>, PhantomData<I>);
+pub(crate) struct ChunkMapInsertBuffer<C>(#[deref] Vec<(IVec3, chunk::ChunkData)>, PhantomData<C>);
 
 #[derive(Resource, Deref, DerefMut, Default)]
-pub(crate) struct ChunkMapUpdateBuffer<I>(
+pub(crate) struct ChunkMapUpdateBuffer<C>(
     #[deref] Vec<(IVec3, chunk::ChunkData, ChunkWillSpawn)>,
-    PhantomData<I>,
+    PhantomData<C>,
 );
 
 #[derive(Resource, Deref, DerefMut, Default)]
-pub(crate) struct ChunkMapRemoveBuffer<I>(#[deref] Vec<IVec3>, PhantomData<I>);
+pub(crate) struct ChunkMapRemoveBuffer<C>(#[deref] Vec<IVec3>, PhantomData<C>);

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -33,7 +33,7 @@ pub enum ChunkSpawnStrategy {
 
 /// Configuration resource for bevy_voxel_world
 #[derive(Resource)]
-pub struct VoxelWorldConfiguration {
+pub struct VoxelWorldConfiguration<I> {
     /// Distance in chunks to spawn chunks around the camera
     pub spawning_distance: u32,
 
@@ -73,9 +73,11 @@ pub struct VoxelWorldConfiguration {
     /// return a function that can be called to check if a voxel exists at a given position. This function
     /// needs to be thread-safe, since chunk computation happens on a separate thread.
     pub voxel_lookup_delegate: VoxelLookupDelegate,
+
+    pub _marker: std::marker::PhantomData<I>,
 }
 
-impl Default for VoxelWorldConfiguration {
+impl<I> Default for VoxelWorldConfiguration<I> {
     fn default() -> Self {
         Self {
             spawning_distance: 10,
@@ -93,6 +95,7 @@ impl Default for VoxelWorldConfiguration {
                 _ => [0, 0, 0],
             }),
             voxel_lookup_delegate: Box::new(|_| Box::new(|_| WorldVoxel::Unset)),
+            _marker: std::marker::PhantomData,
         }
     }
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -101,6 +101,15 @@ pub trait VoxelWorldConfig: Resource + Default + Clone {
     fn voxel_texture(&self) -> Option<(String, u32)> {
         None
     }
+
+    /// Custom material will not get initialized if this returns false. When this is false,
+    /// `VoxelWorldMaterialHandle` needs to be manually added with a reference to the material handle.
+    ///
+    /// This can be used for example if you need to wait for a texture image to load before
+    /// the material can be used.
+    fn init_custom_materials(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Resource, Clone, Default)]

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -31,71 +31,76 @@ pub enum ChunkSpawnStrategy {
     Close,
 }
 
-/// Configuration resource for bevy_voxel_world
-#[derive(Resource)]
-pub struct VoxelWorldConfiguration<I> {
+/// `bevy_voxel_world` configuation structs need to implement this trait
+pub trait VoxelWorldConfig: Resource + Default + Clone {
     /// Distance in chunks to spawn chunks around the camera
-    pub spawning_distance: u32,
+    fn spawning_distance(&self) -> u32 {
+        10
+    }
 
     /// Strategy for despawning chunks
-    pub chunk_despawn_strategy: ChunkDespawnStrategy,
+    fn chunk_despawn_strategy(&self) -> ChunkDespawnStrategy {
+        ChunkDespawnStrategy::default()
+    }
 
     /// Strategy for spawning chunks
     /// This is only used if the despawn strategy is `FarAway`
-    pub chunk_spawn_strategy: ChunkSpawnStrategy,
+    fn chunk_spawn_strategy(&self) -> ChunkSpawnStrategy {
+        ChunkSpawnStrategy::default()
+    }
 
     /// Maximum number of chunks that can get queued for spawning in a given frame.
     /// In some scenarios, reducing this number can help with performance, due to less
     /// thread contention.
-    pub max_spawn_per_frame: usize,
+    fn max_spawn_per_frame(&self) -> usize {
+        10000
+    }
 
     /// Number of rays to cast when spawning chunks. Higher values will result in more
     /// chunks being spawned per frame, but will also increase cpu load, and can lead to
     /// thread contention.
-    pub spawning_rays: usize,
+    fn spawning_rays(&self) -> usize {
+        100
+    }
 
     /// How far outside of the viewports spawning rays should get cast. Higher values will
     /// will reduce the likelyhood of chunks popping in, but will also increase cpu load.
-    pub spawning_ray_margin: u32,
+    fn spawning_ray_margin(&self) -> u32 {
+        25
+    }
 
     /// Debugging aids
-    pub debug_draw_chunks: bool,
+    fn debug_draw_chunks(&self) -> bool {
+        false
+    }
 
     /// A function that maps voxel materials to texture coordinates.
     /// The input is the material index, and the output is a slice of three indexes into an array texture.
     /// The three values correspond to the top, sides and bottom of the voxel. For example,
     /// if the slice is `[1,2,2]`, the top will use texture index 1 and the sides and bottom will use texture
     /// index 2.
-    pub texture_index_mapper: Arc<dyn Fn(u8) -> [u32; 3] + Send + Sync>,
+    fn texture_index_mapper(&self) -> Arc<dyn Fn(u8) -> [u32; 3] + Send + Sync> {
+        Arc::new(|mat| match mat {
+            0 => [0, 0, 0],
+            1 => [1, 1, 1],
+            2 => [2, 2, 2],
+            3 => [3, 3, 3],
+            _ => [0, 0, 0],
+        })
+    }
 
     /// A function that returns a function that returns true if a voxel exists at the given position
     /// The delegate will be called every time a new chunk needs to be computed. The delegate should
     /// return a function that can be called to check if a voxel exists at a given position. This function
     /// needs to be thread-safe, since chunk computation happens on a separate thread.
-    pub voxel_lookup_delegate: VoxelLookupDelegate,
-
-    pub _marker: std::marker::PhantomData<I>,
-}
-
-impl<I> Default for VoxelWorldConfiguration<I> {
-    fn default() -> Self {
-        Self {
-            spawning_distance: 10,
-            chunk_despawn_strategy: ChunkDespawnStrategy::default(),
-            chunk_spawn_strategy: ChunkSpawnStrategy::default(),
-            debug_draw_chunks: true,
-            max_spawn_per_frame: 10000,
-            spawning_rays: 100,
-            spawning_ray_margin: 25,
-            texture_index_mapper: Arc::new(|mat| match mat {
-                0 => [0, 0, 0],
-                1 => [1, 1, 1],
-                2 => [2, 2, 2],
-                3 => [3, 3, 3],
-                _ => [0, 0, 0],
-            }),
-            voxel_lookup_delegate: Box::new(|_| Box::new(|_| WorldVoxel::Unset)),
-            _marker: std::marker::PhantomData,
-        }
+    fn voxel_lookup_delegate(&self) -> VoxelLookupDelegate {
+        Box::new(|_| Box::new(|_| WorldVoxel::Unset))
     }
 }
+
+#[derive(Resource, Clone, Default)]
+pub struct DefaultWorld;
+
+impl DefaultWorld {}
+
+impl VoxelWorldConfig for DefaultWorld {}

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -96,6 +96,11 @@ pub trait VoxelWorldConfig: Resource + Default + Clone {
     fn voxel_lookup_delegate(&self) -> VoxelLookupDelegate {
         Box::new(|_| Box::new(|_| WorldVoxel::Unset))
     }
+
+    /// A tuple of the path to the texture and the number of indexes in the texture. `None` if no texture is used.
+    fn voxel_texture(&self) -> Option<(String, u32)> {
+        None
+    }
 }
 
 #[derive(Resource, Clone, Default)]

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -4,11 +4,11 @@ use bevy::{prelude::*, render::primitives::Aabb};
 
 use crate::chunk::Chunk;
 
-pub struct VoxelWorldGizmoPlugin<I>(PhantomData<I>);
+pub struct VoxelWorldGizmoPlugin<C>(PhantomData<C>);
 
-impl<I: Send + Sync + 'static> Plugin for VoxelWorldGizmoPlugin<I> {
+impl<C: Send + Sync + 'static> Plugin for VoxelWorldGizmoPlugin<C> {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, draw_aabbs::<I>);
+        app.add_systems(Update, draw_aabbs::<C>);
     }
 }
 
@@ -17,8 +17,8 @@ pub struct ChunkAabbGizmo {
     pub color: Option<Color>,
 }
 
-fn draw_aabbs<I: Send + Sync + 'static>(
-    query: Query<(&Chunk<I>, &GlobalTransform, &ChunkAabbGizmo)>,
+fn draw_aabbs<C: Send + Sync + 'static>(
+    query: Query<(&Chunk<C>, &GlobalTransform, &ChunkAabbGizmo)>,
     mut gizmos: Gizmos,
 ) {
     for (chunk, &transform, gizmo) in &query {

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,12 +1,14 @@
+use std::marker::PhantomData;
+
 use bevy::{prelude::*, render::primitives::Aabb};
 
 use crate::chunk::Chunk;
 
-pub struct VoxelWorldGizmoPlugin;
+pub struct VoxelWorldGizmoPlugin<I>(PhantomData<I>);
 
-impl Plugin for VoxelWorldGizmoPlugin {
+impl<I: Send + Sync + 'static> Plugin for VoxelWorldGizmoPlugin<I> {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, draw_aabbs);
+        app.add_systems(Update, draw_aabbs::<I>);
     }
 }
 
@@ -15,7 +17,10 @@ pub struct ChunkAabbGizmo {
     pub color: Option<Color>,
 }
 
-fn draw_aabbs(query: Query<(&Chunk, &GlobalTransform, &ChunkAabbGizmo)>, mut gizmos: Gizmos) {
+fn draw_aabbs<I: Send + Sync + 'static>(
+    query: Query<(&Chunk<I>, &GlobalTransform, &ChunkAabbGizmo)>,
+    mut gizmos: Gizmos,
+) {
     for (chunk, &transform, gizmo) in &query {
         let color = gizmo.color.unwrap_or(Color::WHITE);
         gizmos.cuboid(aabb_transform(chunk.aabb(), transform), color);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod prelude {
 }
 
 pub mod rendering {
+    pub use crate::plugin::VoxelWorldMaterialHandle;
     pub use crate::voxel_material::vertex_layout;
     pub use crate::voxel_material::VOXEL_TEXTURE_SHADER_HANDLE;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@ pub mod prelude {
 }
 
 pub mod rendering {
-    pub use crate::plugin::{VoxelWorldMaterialHandle, VoxelWorldMaterialPlugin};
     pub use crate::voxel_material::vertex_layout;
     pub use crate::voxel_material::VOXEL_TEXTURE_SHADER_HANDLE;
 }

--- a/src/mesh_cache.rs
+++ b/src/mesh_cache.rs
@@ -17,13 +17,13 @@ type WeakMeshMap = WeakValueHashMap<u64, Weak<Handle<Mesh>>>;
 /// Using this map, we can avoid generating the same mesh multiple times, and reusing mesh handles
 /// should allow Bevy to automatically batch draw identical chunks (large flat areas for example)
 #[derive(Resource, Clone)]
-pub(crate) struct MeshCache<I> {
+pub(crate) struct MeshCache<C> {
     map: Arc<RwLock<WeakMeshMap>>,
-    _marker: std::marker::PhantomData<I>,
+    _marker: std::marker::PhantomData<C>,
 }
 
-impl<I: Send + Sync + 'static> MeshCache<I> {
-    pub fn apply_buffers(&self, insert_buffer: &mut MeshCacheInsertBuffer<I>) {
+impl<C: Send + Sync + 'static> MeshCache<C> {
+    pub fn apply_buffers(&self, insert_buffer: &mut MeshCacheInsertBuffer<C>) {
         if insert_buffer.len() == 0 {
             return;
         }
@@ -45,7 +45,7 @@ impl<I: Send + Sync + 'static> MeshCache<I> {
     }
 }
 
-impl<I> Default for MeshCache<I> {
+impl<C> Default for MeshCache<C> {
     fn default() -> Self {
         Self {
             map: Arc::new(RwLock::new(WeakMeshMap::with_capacity(2000))),
@@ -55,4 +55,4 @@ impl<I> Default for MeshCache<I> {
 }
 
 #[derive(Resource, Deref, DerefMut, Default)]
-pub(crate) struct MeshCacheInsertBuffer<I>(#[deref] Vec<(u64, Arc<Handle<Mesh>>)>, PhantomData<I>);
+pub(crate) struct MeshCacheInsertBuffer<C>(#[deref] Vec<(u64, Arc<Handle<Mesh>>)>, PhantomData<C>);

--- a/src/mesh_cache.rs
+++ b/src/mesh_cache.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, RwLock, Weak};
+use std::{
+    marker::PhantomData,
+    sync::{Arc, RwLock, Weak},
+};
 
 use bevy::prelude::*;
 use weak_table::WeakValueHashMap;
@@ -14,12 +17,13 @@ type WeakMeshMap = WeakValueHashMap<u64, Weak<Handle<Mesh>>>;
 /// Using this map, we can avoid generating the same mesh multiple times, and reusing mesh handles
 /// should allow Bevy to automatically batch draw identical chunks (large flat areas for example)
 #[derive(Resource, Clone)]
-pub(crate) struct MeshCache {
+pub(crate) struct MeshCache<I> {
     map: Arc<RwLock<WeakMeshMap>>,
+    _marker: std::marker::PhantomData<I>,
 }
 
-impl MeshCache {
-    pub fn apply_buffers(&self, insert_buffer: &mut MeshCacheInsertBuffer) {
+impl<I: Send + Sync + 'static> MeshCache<I> {
+    pub fn apply_buffers(&self, insert_buffer: &mut MeshCacheInsertBuffer<I>) {
         if insert_buffer.len() == 0 {
             return;
         }
@@ -41,13 +45,14 @@ impl MeshCache {
     }
 }
 
-impl Default for MeshCache {
+impl<I> Default for MeshCache<I> {
     fn default() -> Self {
         Self {
             map: Arc::new(RwLock::new(WeakMeshMap::with_capacity(2000))),
+            _marker: std::marker::PhantomData,
         }
     }
 }
 
 #[derive(Resource, Deref, DerefMut, Default)]
-pub(crate) struct MeshCacheInsertBuffer(Vec<(u64, Arc<Handle<Mesh>>)>);
+pub(crate) struct MeshCacheInsertBuffer<I>(#[deref] Vec<(u64, Arc<Handle<Mesh>>)>, PhantomData<I>);

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,5 +1,4 @@
 use bevy::{
-    app::Plugins,
     asset::load_internal_asset,
     pbr::ExtendedMaterial,
     prelude::*,
@@ -89,7 +88,7 @@ impl Default for VoxelWorldPlugin<DefaultWorld, StandardMaterial> {
         Self {
             spawn_meshes: true,
             use_custom_material: false,
-            config: DefaultWorld::default(),
+            config: DefaultWorld,
             material: StandardMaterial::default(),
         }
     }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -211,10 +211,11 @@ where
         }
 
         if self.use_custom_material {
-            let mut custom_material_assets = app.world.resource_mut::<Assets<M>>();
-
-            let handle = custom_material_assets.add(self.material.clone());
-            app.insert_resource(VoxelWorldMaterialHandle { handle });
+            if self.config.init_custom_materials() {
+                let mut custom_material_assets = app.world.resource_mut::<Assets<M>>();
+                let handle = custom_material_assets.add(self.material.clone());
+                app.insert_resource(VoxelWorldMaterialHandle { handle });
+            }
 
             app.insert_resource(LoadingTexture {
                 is_loaded: true,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -65,6 +65,12 @@ where
     C: VoxelWorldConfig,
     M: Material,
 {
+    /// Use this to tell `bevy_voxel_world` to use a custom material. This can be any material that
+    /// implements `bevy::pbr::Material`. You can use this to create custom shaders for your voxel
+    /// world. You can set this up like any other material in Bevy.
+    ///
+    /// `bevy_voxel_world` will add the material as an asset, so you can query for it later using
+    /// `Res<Assets<MyCustomVoxelMaterialType>>`.
     pub fn with_material<CustomMaterial: Material>(
         self,
         material: CustomMaterial,

--- a/src/voxel_world.rs
+++ b/src/voxel_world.rs
@@ -189,7 +189,7 @@ impl VoxelRaycastResult {
 
 /// SystemParam helper for raycasting into the voxel world
 #[derive(SystemParam)]
-pub struct VoxelWorldRaycast<'w, C: VoxelWorldConfig = DefaultWorld> {
+pub struct VoxelWorldRaycast<'w, C: VoxelWorldConfig> {
     configuration: Res<'w, C>,
     chunk_map: Res<'w, ChunkMap<C>>,
     voxel_world: VoxelWorld<'w, C>,

--- a/src/voxel_world.rs
+++ b/src/voxel_world.rs
@@ -215,7 +215,7 @@ impl<'w, C: VoxelWorldConfig> VoxelWorldRaycast<'w, C> {
     /// use bevy_voxel_world::prelude::*;
     ///
     /// fn do_raycast(
-    ///     voxel_world_raycast: VoxelWorldRaycast,
+    ///     voxel_world_raycast: VoxelWorldRaycast<DefaultWorld>,
     ///     camera_info: Query<(&Camera, &GlobalTransform), With<VoxelWorldCamera>>,
     ///     mut cursor_evr: EventReader<CursorMoved>,
     /// ) {

--- a/src/voxel_world.rs
+++ b/src/voxel_world.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use crate::{
     chunk::{CHUNK_SIZE_F, CHUNK_SIZE_I},
     chunk_map::ChunkMap,
-    configuration::VoxelWorldConfiguration,
+    configuration::{DefaultWorld, VoxelWorldConfig},
     voxel::{VoxelAabb, WorldVoxel},
     voxel_world_internal::{get_chunk_voxel_position, ModifiedVoxels, VoxelWriteBuffer},
 };
@@ -41,13 +41,13 @@ pub struct ChunkWillRemesh {
 
 /// Grants access to the VoxelWorld in systems
 #[derive(SystemParam)]
-pub struct VoxelWorld<'w, I: Clone + Send + Sync + 'static> {
-    chunk_map: Res<'w, ChunkMap<I>>,
-    modified_voxels: Res<'w, ModifiedVoxels<I>>,
-    voxel_write_buffer: ResMut<'w, VoxelWriteBuffer<I>>,
+pub struct VoxelWorld<'w, C: VoxelWorldConfig> {
+    chunk_map: Res<'w, ChunkMap<C>>,
+    modified_voxels: Res<'w, ModifiedVoxels<C>>,
+    voxel_write_buffer: ResMut<'w, VoxelWriteBuffer<C>>,
 }
 
-impl<'w, I: Clone + Send + Sync + 'static> VoxelWorld<'w, I> {
+impl<'w, C: VoxelWorldConfig> VoxelWorld<'w, C> {
     /// Get the voxel at the given position. The voxel will be WorldVoxel::Unset if there is no voxel at that position
     pub fn get_voxel(&self, position: IVec3) -> WorldVoxel {
         self.get_voxel_fn()(position)
@@ -189,15 +189,15 @@ impl VoxelRaycastResult {
 
 /// SystemParam helper for raycasting into the voxel world
 #[derive(SystemParam)]
-pub struct VoxelWorldRaycast<'w, I: Clone + Send + Sync + 'static> {
-    configuration: Res<'w, VoxelWorldConfiguration<I>>,
-    chunk_map: Res<'w, ChunkMap<I>>,
-    voxel_world: VoxelWorld<'w, I>,
+pub struct VoxelWorldRaycast<'w, C: VoxelWorldConfig = DefaultWorld> {
+    configuration: Res<'w, C>,
+    chunk_map: Res<'w, ChunkMap<C>>,
+    voxel_world: VoxelWorld<'w, C>,
 }
 
 const STEP_SIZE: f32 = 0.01;
 
-impl<'w, I: Clone + Send + Sync + 'static> VoxelWorldRaycast<'w, I> {
+impl<'w, C: VoxelWorldConfig> VoxelWorldRaycast<'w, C> {
     /// Get the first solid voxel intersecting with the given ray.
     /// The `filter` function can be used to filter out voxels that should not be considered for the raycast.
     ///
@@ -237,7 +237,7 @@ impl<'w, I: Clone + Send + Sync + 'static> VoxelWorldRaycast<'w, I> {
         ray: Ray3d,
         filter: &impl Fn((Vec3, WorldVoxel)) -> bool,
     ) -> Option<VoxelRaycastResult> {
-        let spawning_distance = self.configuration.spawning_distance as i32;
+        let spawning_distance = self.configuration.spawning_distance() as i32;
         let chunk_map_read_lock = self.chunk_map.get_read_lock();
         let mut current = ray.origin;
         let mut t = 0.0;
@@ -245,7 +245,7 @@ impl<'w, I: Clone + Send + Sync + 'static> VoxelWorldRaycast<'w, I> {
         while t < (spawning_distance * CHUNK_SIZE_I) as f32 {
             let chunk_pos = (current / CHUNK_SIZE_F).floor().as_ivec3();
 
-            if let Some(chunk_data) = ChunkMap::<I>::get(&chunk_pos, &chunk_map_read_lock) {
+            if let Some(chunk_data) = ChunkMap::<C>::get(&chunk_pos, &chunk_map_read_lock) {
                 if !chunk_data.is_empty {
                     let mut voxel = WorldVoxel::Unset;
                     while voxel == WorldVoxel::Unset && chunk_data.encloses_point(current) {

--- a/src/voxel_world.rs
+++ b/src/voxel_world.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use crate::{
     chunk::{CHUNK_SIZE_F, CHUNK_SIZE_I},
     chunk_map::ChunkMap,
-    configuration::{DefaultWorld, VoxelWorldConfig},
+    configuration::VoxelWorldConfig,
     voxel::{VoxelAabb, WorldVoxel},
     voxel_world_internal::{get_chunk_voxel_position, ModifiedVoxels, VoxelWriteBuffer},
 };

--- a/src/voxel_world_internal.rs
+++ b/src/voxel_world_internal.rs
@@ -308,6 +308,7 @@ impl<C: VoxelWorldConfig> Internals<C> {
     }
 
     /// Inserts new meshes for chunks that have just finished remeshing
+    #[allow(clippy::type_complexity)]
     pub fn spawn_meshes(
         mut commands: Commands,
         mut chunking_threads: Query<

--- a/src/voxel_world_internal.rs
+++ b/src/voxel_world_internal.rs
@@ -57,7 +57,7 @@ impl<C: VoxelWorldConfig> ModifiedVoxels<C> {
 pub struct VoxelWriteBuffer<C>(#[deref] Vec<(IVec3, WorldVoxel)>, PhantomData<C>);
 
 #[derive(Component)]
-pub(crate) struct NeedsMaterial;
+pub(crate) struct NeedsMaterial<C>(PhantomData<C>);
 
 pub(crate) struct Internals<C>(PhantomData<C>);
 
@@ -361,7 +361,11 @@ impl<C: VoxelWorldConfig> Internals<C> {
 
                     commands
                         .entity(entity)
-                        .try_insert((*transform, MeshRef(mesh_handle), NeedsMaterial))
+                        .try_insert((
+                            *transform,
+                            MeshRef(mesh_handle),
+                            NeedsMaterial::<C>(PhantomData),
+                        ))
                         .remove::<bevy::render::primitives::Aabb>();
                 }
 
@@ -426,7 +430,7 @@ impl<C: VoxelWorldConfig> Internals<C> {
 
     pub(crate) fn assign_material<M: Material>(
         mut commands: Commands,
-        mut needs_material: Query<(Entity, &MeshRef, &Transform), With<NeedsMaterial>>,
+        mut needs_material: Query<(Entity, &MeshRef, &Transform), With<NeedsMaterial<C>>>,
         material_handle: Option<Res<VoxelWorldMaterialHandle<M>>>,
     ) {
         let Some(material_handle) = material_handle else {
@@ -442,7 +446,7 @@ impl<C: VoxelWorldConfig> Internals<C> {
                     transform: *transform,
                     ..default()
                 })
-                .remove::<NeedsMaterial>();
+                .remove::<NeedsMaterial<C>>();
         }
     }
 }


### PR DESCRIPTION
Add support for multiple parallell world instances

## Breaking changes:

### Configuration is now supplied when adding the plugin

  ```rust
  // First declare a config struct. It needs to derive `Resource`, `Clone` and `Default`
  #[derive(Resource, Clone, Default)]
  struct MyWorld;

  // Then implement the `VoxelWorldConfig` trait for it:
  impl VoxelWorldConfig for MyWorld {
      // All the trait methods have defaults, so you only need to add the ones you want to alter
      fn spawning_distance(&self) -> u32 {
         15
      }
  }
  ```

  Then when adding the plugin:

  ```rust
  .add_plugins(VoxelWorldPlugin::with_config(MyWorld))
  ```

  If you don't want to change any default config, you can simply do this:

  ```rust
  .add_plugins(VoxelWorldPlugin::default())
  ```

Adding multiple worlds follows the same pattern. Just create different configuration structs and add a `VoxelWorldPlugin` for each.

  ```rust
  .add_plugins(VoxelWorldPlugin::with_config(MyOtherWorld))
  ```

Each world instance can have it's own configuration and will keep track of it's own set of voxel data and chunks.

### The `VoxelWorld` system param now needs a type parameter to specify which world instance you want to select

The configuration struct adds the config values and its type also acts as a marker for the world instance.

  ```rust
  fn my_system(
    my_voxel_world: VoxelWorld<MyWorld>,
    my_other_voxel_world: VoxelWorld<MyOtherWorld>
  ) {
    // Set a voxel in `my_voxel_world`
    my_voxel_world.set_voxel(pos, WorldVoxel::Solid(voxel_type))

    // Set a voxel in `my_other_voxel_world`
    my_other_voxel_world.set_voxel(pos, WorldVoxel::Solid(voxel_type))
  }
  ```

  If you initialized the plugin with `::default()`, you still need to explicitly specify the instance as `DefaultWorld`:

  ```rust
  fn my_system(voxel_world: VoxelWorld<DefaultWorld>) { ... }
  ```

The `VoxelWorldRaycast` system param now also requires the same config type paramter as described above.