### PR TITLE
Add WorldConfig constraint to the Chunk events

### DIFF
--- a/examples/bombs.rs
+++ b/examples/bombs.rs
@@ -115,7 +115,10 @@ fn get_voxel_fn() -> Box<dyn FnMut(IVec3) -> WorldVoxel + Send + Sync> {
     })
 }
 
-fn move_camera(time: Res<Time>, mut cam_transform: Query<&mut Transform, With<VoxelWorldCamera<MainWorld>>>) {
+fn move_camera(
+    time: Res<Time>,
+    mut cam_transform: Query<&mut Transform, With<VoxelWorldCamera<MainWorld>>>,
+) {
     cam_transform.single_mut().translation.x += time.delta_seconds() * 7.0;
     cam_transform.single_mut().translation.z += time.delta_seconds() * 12.0;
 }

--- a/examples/bombs.rs
+++ b/examples/bombs.rs
@@ -43,8 +43,8 @@ fn setup(mut commands: Commands) {
             transform: Transform::from_xyz(-120.0, 150.0, -120.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..default()
         },
-        // This tells bevy_voxel_world tos use this cameras transform to calculate spawning area
-        VoxelWorldCamera,
+        // This tells bevy_voxel_world to use this cameras transform to calculate spawning area
+        VoxelWorldCamera::<MainWorld>::default(),
     ));
 
     // Sun
@@ -115,14 +115,14 @@ fn get_voxel_fn() -> Box<dyn FnMut(IVec3) -> WorldVoxel + Send + Sync> {
     })
 }
 
-fn move_camera(time: Res<Time>, mut cam_transform: Query<&mut Transform, With<VoxelWorldCamera>>) {
+fn move_camera(time: Res<Time>, mut cam_transform: Query<&mut Transform, With<VoxelWorldCamera<MainWorld>>>) {
     cam_transform.single_mut().translation.x += time.delta_seconds() * 7.0;
     cam_transform.single_mut().translation.z += time.delta_seconds() * 12.0;
 }
 
 fn explosion(
     mut voxel_world: VoxelWorld<MainWorld>,
-    camera: Query<&Transform, With<VoxelWorldCamera>>,
+    camera: Query<&Transform, With<VoxelWorldCamera<MainWorld>>>,
     mut timeout: Query<&mut ExplosionTimeout>,
     time: Res<Time>,
 ) {

--- a/examples/custom_material.rs
+++ b/examples/custom_material.rs
@@ -59,7 +59,7 @@ fn setup(mut commands: Commands) {
             transform: Transform::from_xyz(5.0, 5.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..default()
         },
-        VoxelWorldCamera,
+        VoxelWorldCamera::<MyMainWorld>::default(),
     ));
 }
 

--- a/examples/multiple_worlds.rs
+++ b/examples/multiple_worlds.rs
@@ -72,8 +72,9 @@ fn setup(mut commands: Commands, mut second_world: VoxelWorld<SecondWorld>) {
             transform: Transform::from_xyz(-10.0, 10.0, -10.0).looking_at(Vec3::Y * 4.0, Vec3::Y),
             ..default()
         },
-        // This tells bevy_voxel_world tos use this cameras transform to calculate spawning area
-        VoxelWorldCamera,
+        // This tells bevy_voxel_world to use this cameras transform to calculate spawning area
+        VoxelWorldCamera::<MainWorld>::default(),
+        VoxelWorldCamera::<SecondWorld>::default(),
     ));
 
     // Sun

--- a/examples/noise_terrain.rs
+++ b/examples/noise_terrain.rs
@@ -31,8 +31,8 @@ fn setup(mut commands: Commands) {
             transform: Transform::from_xyz(-200.0, 180.0, -200.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..default()
         },
-        // This tells bevy_voxel_world tos use this cameras transform to calculate spawning area
-        VoxelWorldCamera,
+        // This tells bevy_voxel_world to use this cameras transform to calculate spawning area
+        VoxelWorldCamera::<MainWorld>::default(),
     ));
 
     // Sun
@@ -97,7 +97,7 @@ fn get_voxel_fn() -> Box<dyn FnMut(IVec3) -> WorldVoxel + Send + Sync> {
     })
 }
 
-fn move_camera(time: Res<Time>, mut cam_transform: Query<&mut Transform, With<VoxelWorldCamera>>) {
+fn move_camera(time: Res<Time>, mut cam_transform: Query<&mut Transform, With<VoxelWorldCamera<MainWorld>>>) {
     cam_transform.single_mut().translation.x += time.delta_seconds() * 30.0;
     cam_transform.single_mut().translation.z += time.delta_seconds() * 60.0;
 }

--- a/examples/noise_terrain.rs
+++ b/examples/noise_terrain.rs
@@ -97,7 +97,10 @@ fn get_voxel_fn() -> Box<dyn FnMut(IVec3) -> WorldVoxel + Send + Sync> {
     })
 }
 
-fn move_camera(time: Res<Time>, mut cam_transform: Query<&mut Transform, With<VoxelWorldCamera<MainWorld>>>) {
+fn move_camera(
+    time: Res<Time>,
+    mut cam_transform: Query<&mut Transform, With<VoxelWorldCamera<MainWorld>>>,
+) {
     cam_transform.single_mut().translation.x += time.delta_seconds() * 30.0;
     cam_transform.single_mut().translation.z += time.delta_seconds() * 60.0;
 }

--- a/examples/ray_cast.rs
+++ b/examples/ray_cast.rs
@@ -1,6 +1,7 @@
 use bevy::prelude::*;
 use bevy_voxel_world::prelude::*;
 use std::sync::Arc;
+use bevy::render::MainWorld;
 
 // Declare materials as consts for convenience
 const SNOWY_BRICK: u8 = 0;
@@ -66,8 +67,8 @@ fn setup(
             transform: Transform::from_xyz(10.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..default()
         },
-        // This tells bevy_voxel_world tos use this cameras transform to calculate spawning area
-        VoxelWorldCamera,
+        // This tells bevy_voxel_world to use this cameras transform to calculate spawning area
+        VoxelWorldCamera::<MainWorld>::default(),
     ));
 
     // light
@@ -106,7 +107,7 @@ fn create_voxel_scene(mut voxel_world: VoxelWorld<MyMainWorld>) {
 
 fn update_cursor_cube(
     voxel_world_raycast: VoxelWorld<MyMainWorld>,
-    camera_info: Query<(&Camera, &GlobalTransform), With<VoxelWorldCamera>>,
+    camera_info: Query<(&Camera, &GlobalTransform), With<VoxelWorldCamera<MainWorld>>>,
     mut cursor_evr: EventReader<CursorMoved>,
     mut cursor_cube: Query<(&mut Transform, &mut CursorCube)>,
 ) {

--- a/examples/ray_cast.rs
+++ b/examples/ray_cast.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
+use bevy::render::MainWorld;
 use bevy_voxel_world::prelude::*;
 use std::sync::Arc;
-use bevy::render::MainWorld;
 
 // Declare materials as consts for convenience
 const SNOWY_BRICK: u8 = 0;

--- a/examples/set_voxel.rs
+++ b/examples/set_voxel.rs
@@ -19,7 +19,7 @@ fn setup(mut commands: Commands) {
             ..default()
         },
         // This tells bevy_voxel_world to use this cameras transform to calculate spawning area
-        VoxelWorldCamera,
+        VoxelWorldCamera::<DefaultWorld>::default(),
     ));
 
     // Ambient light
@@ -46,7 +46,7 @@ fn set_solid_voxel(mut voxel_world: VoxelWorld<DefaultWorld>) {
 }
 
 // Rotate the camera around the origin
-fn move_camera(time: Res<Time>, mut query: Query<&mut Transform, With<VoxelWorldCamera>>) {
+fn move_camera(time: Res<Time>, mut query: Query<&mut Transform, With<VoxelWorldCamera<DefaultWorld>>>) {
     let mut transform = query.single_mut();
     let time_seconds = time.elapsed_seconds();
     transform.translation.x = 25.0 * (time_seconds * 0.1).sin();

--- a/examples/set_voxel.rs
+++ b/examples/set_voxel.rs
@@ -46,7 +46,10 @@ fn set_solid_voxel(mut voxel_world: VoxelWorld<DefaultWorld>) {
 }
 
 // Rotate the camera around the origin
-fn move_camera(time: Res<Time>, mut query: Query<&mut Transform, With<VoxelWorldCamera<DefaultWorld>>>) {
+fn move_camera(
+    time: Res<Time>,
+    mut query: Query<&mut Transform, With<VoxelWorldCamera<DefaultWorld>>>,
+) {
     let mut transform = query.single_mut();
     let time_seconds = time.elapsed_seconds();
     transform.translation.x = 25.0 * (time_seconds * 0.1).sin();

--- a/examples/textures.rs
+++ b/examples/textures.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
+use bevy::render::MainWorld;
 use bevy_voxel_world::prelude::*;
 use std::sync::Arc;
-use bevy::render::MainWorld;
 
 // Declare materials as consts for convenience
 const SNOWY_BRICK: u8 = 0;

--- a/examples/textures.rs
+++ b/examples/textures.rs
@@ -1,6 +1,7 @@
 use bevy::prelude::*;
 use bevy_voxel_world::prelude::*;
 use std::sync::Arc;
+use bevy::render::MainWorld;
 
 // Declare materials as consts for convenience
 const SNOWY_BRICK: u8 = 0;
@@ -42,7 +43,7 @@ fn setup(mut commands: Commands) {
             ..default()
         },
         // This tells bevy_voxel_world to use this cameras transform to calculate spawning area
-        VoxelWorldCamera,
+        VoxelWorldCamera::<MainWorld>::default(),
     ));
 
     // light

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -23,14 +23,14 @@ pub(crate) type VoxelArray = [WorldVoxel; PaddedChunkShape::SIZE as usize];
 
 #[derive(Component)]
 #[component(storage = "SparseSet")]
-pub(crate) struct ChunkThread<C>(pub Task<ChunkTask<C>>, pub IVec3, PhantomData<C>);
+pub(crate) struct ChunkThread<C>(pub Task<ChunkTask<C>>, PhantomData<C>);
 
 impl<C> ChunkThread<C>
 where
     C: Send + Sync + 'static,
 {
-    pub fn new(task: Task<ChunkTask<C>>, pos: IVec3) -> Self {
-        Self(task, pos, PhantomData)
+    pub fn new(task: Task<ChunkTask<C>>, _pos: IVec3) -> Self {
+        Self(task, PhantomData)
     }
 }
 

--- a/src/chunk_map.rs
+++ b/src/chunk_map.rs
@@ -47,7 +47,7 @@ impl<C: Send + Sync + 'static> ChunkMap<C> {
         insert_buffer: &mut ChunkMapInsertBuffer<C>,
         update_buffer: &mut ChunkMapUpdateBuffer<C>,
         remove_buffer: &mut ChunkMapRemoveBuffer<C>,
-        ev_chunk_will_spawn: &mut EventWriter<ChunkWillSpawn>,
+        ev_chunk_will_spawn: &mut EventWriter<ChunkWillSpawn<C>>,
     ) {
         if insert_buffer.is_empty() && update_buffer.is_empty() && remove_buffer.is_empty() {
             return;
@@ -99,7 +99,7 @@ pub(crate) struct ChunkMapInsertBuffer<C>(#[deref] Vec<(IVec3, chunk::ChunkData)
 
 #[derive(Resource, Deref, DerefMut, Default)]
 pub(crate) struct ChunkMapUpdateBuffer<C>(
-    #[deref] Vec<(IVec3, chunk::ChunkData, ChunkWillSpawn)>,
+    #[deref] Vec<(IVec3, chunk::ChunkData, ChunkWillSpawn<C>)>,
     PhantomData<C>,
 );
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -121,9 +121,9 @@ where
                         .chain(),
                 ),
             )
-            .add_event::<ChunkWillSpawn>()
-            .add_event::<ChunkWillDespawn>()
-            .add_event::<ChunkWillRemesh>();
+            .add_event::<ChunkWillSpawn<C>>()
+            .add_event::<ChunkWillDespawn<C>>()
+            .add_event::<ChunkWillRemesh<C>>();
 
         // Spawning of meshes is optional, mainly to simplify testing.
         // This makes voxel_world work with a MinimalPlugins setup.

--- a/src/test.rs
+++ b/src/test.rs
@@ -18,7 +18,7 @@ fn _test_setup_app() -> App {
                 transform: Transform::from_xyz(10.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
                 ..default()
             },
-            VoxelWorldCamera,
+            VoxelWorldCamera::<DefaultWorld>::default(),
         ));
     });
 
@@ -151,7 +151,7 @@ fn chunk_will_despawn_event() {
     // move camera to simulate chunks going out of view
     app.add_systems(
         Update,
-        |mut query: Query<&mut GlobalTransform, With<VoxelWorldCamera>>| {
+        |mut query: Query<&mut GlobalTransform, With<VoxelWorldCamera<DefaultWorld>>>| {
             for mut transform in query.iter_mut() {
                 // Not sure why, but when running tests, bevy won't update the GlobalTransform
                 // when a Transform has changed, so as a workaround we set it here directly.

--- a/src/test.rs
+++ b/src/test.rs
@@ -109,7 +109,7 @@ fn chunk_will_spawn_events() {
 
     app.add_systems(
         Update,
-        |mut ev_chunk_will_spawn: EventReader<ChunkWillSpawn>| {
+        |mut ev_chunk_will_spawn: EventReader<ChunkWillSpawn<DefaultWorld>>| {
             let spawn_count = ev_chunk_will_spawn.read().count();
             assert!(spawn_count > 0);
         },
@@ -135,7 +135,7 @@ fn chunk_will_remesh_event_after_set_voxel() {
 
     app.add_systems(
         Update,
-        |mut ev_chunk_will_remesh: EventReader<ChunkWillRemesh>| {
+        |mut ev_chunk_will_remesh: EventReader<ChunkWillRemesh<DefaultWorld>>| {
             let count = ev_chunk_will_remesh.read().count();
             assert!(count > 0)
         },
@@ -165,7 +165,7 @@ fn chunk_will_despawn_event() {
 
     app.add_systems(
         Update,
-        |mut ev_chunk_will_despawn: EventReader<ChunkWillDespawn>| {
+        |mut ev_chunk_will_despawn: EventReader<ChunkWillDespawn<DefaultWorld>>| {
             let count = ev_chunk_will_despawn.read().count();
             assert!(count > 0)
         },
@@ -209,10 +209,7 @@ fn raycast_finds_voxel() {
                     fill_type: FillType::Mixed,
                     entity: Entity::PLACEHOLDER,
                 },
-                ChunkWillSpawn {
-                    chunk_key: IVec3::new(0, 0, 0),
-                    entity: Entity::PLACEHOLDER,
-                },
+                ChunkWillSpawn::<DefaultWorld>::new(IVec3::new(0, 0, 0), Entity::PLACEHOLDER),
             ));
         },
     );

--- a/src/voxel_world.rs
+++ b/src/voxel_world.rs
@@ -19,29 +19,14 @@ use crate::{
 #[derive(Component)]
 pub struct VoxelWorldCamera;
 
-/// Fired when a chunk is about to be despawned.
 #[derive(Event)]
-pub struct ChunkWillDespawn<C> {
+pub struct ChunkEvent<C> {
     pub chunk_key: IVec3,
     pub entity: Entity,
     _marker: PhantomData<C>,
 }
 
-impl<C> ChunkWillDespawn<C> {
-    pub fn new(chunk_key: IVec3, entity: Entity) -> Self {
-        Self { chunk_key, entity, _marker: PhantomData }
-    }
-}
-
-/// Fired when a chunk is about to be spawned.
-#[derive(Event, Clone)]
-pub struct ChunkWillSpawn<C> {
-    pub chunk_key: IVec3,
-    pub entity: Entity,
-    _marker: PhantomData<C>,
-}
-
-impl<C> ChunkWillSpawn<C> {
+impl<C> ChunkEvent<C> {
     pub fn new(chunk_key: IVec3, entity: Entity) -> Self {
         Self { chunk_key, entity, _marker: PhantomData }
     }
@@ -51,19 +36,14 @@ impl<C> ChunkWillSpawn<C> {
     }
 }
 
-/// Fired when a chunk is about to be remeshed.
-#[derive(Event)]
-pub struct ChunkWillRemesh<C> {
-    pub chunk_key: IVec3,
-    pub entity: Entity,
-    _marker: PhantomData<C>,
-}
+/// Fired when a chunk is about to be despawned.
+pub type ChunkWillDespawn<C> = ChunkEvent<C>;
 
-impl<C> ChunkWillRemesh<C> {
-    pub fn new(chunk_key: IVec3, entity: Entity) -> Self {
-        Self { chunk_key, entity, _marker: PhantomData }
-    }
-}
+/// Fired when a chunk is about to be spawned.
+pub type ChunkWillSpawn<C> = ChunkEvent<C>;
+
+/// Fired when a chunk is about to be remeshed.
+pub type ChunkWillRemesh<C> = ChunkEvent<C>;
 
 pub trait FilterFn {
     fn call(&self, input: (Vec3, WorldVoxel)) -> bool;

--- a/src/voxel_world.rs
+++ b/src/voxel_world.rs
@@ -4,6 +4,7 @@
 ///
 use bevy::{ecs::system::SystemParam, prelude::*, render::primitives::Aabb};
 use std::sync::Arc;
+use std::marker::PhantomData;
 
 use crate::{
     chunk::{CHUNK_SIZE_F, CHUNK_SIZE_I},
@@ -20,23 +21,48 @@ pub struct VoxelWorldCamera;
 
 /// Fired when a chunk is about to be despawned.
 #[derive(Event)]
-pub struct ChunkWillDespawn {
+pub struct ChunkWillDespawn<C> {
     pub chunk_key: IVec3,
     pub entity: Entity,
+    _marker: PhantomData<C>,
+}
+
+impl<C> ChunkWillDespawn<C> {
+    pub fn new(chunk_key: IVec3, entity: Entity) -> Self {
+        Self { chunk_key, entity, _marker: PhantomData }
+    }
 }
 
 /// Fired when a chunk is about to be spawned.
 #[derive(Event, Clone)]
-pub struct ChunkWillSpawn {
+pub struct ChunkWillSpawn<C> {
     pub chunk_key: IVec3,
     pub entity: Entity,
+    _marker: PhantomData<C>,
+}
+
+impl<C> ChunkWillSpawn<C> {
+    pub fn new(chunk_key: IVec3, entity: Entity) -> Self {
+        Self { chunk_key, entity, _marker: PhantomData }
+    }
+
+    pub fn clone(&self) -> Self {
+        Self { chunk_key: self.chunk_key.clone(), entity: self.entity.clone(), _marker: PhantomData }
+    }
 }
 
 /// Fired when a chunk is about to be remeshed.
 #[derive(Event)]
-pub struct ChunkWillRemesh {
+pub struct ChunkWillRemesh<C> {
     pub chunk_key: IVec3,
     pub entity: Entity,
+    _marker: PhantomData<C>,
+}
+
+impl<C> ChunkWillRemesh<C> {
+    pub fn new(chunk_key: IVec3, entity: Entity) -> Self {
+        Self { chunk_key, entity, _marker: PhantomData }
+    }
 }
 
 pub trait FilterFn {

--- a/src/voxel_world.rs
+++ b/src/voxel_world.rs
@@ -3,8 +3,8 @@
 /// This module implements most of the public API for bevy_voxel_world.
 ///
 use bevy::{ecs::system::SystemParam, prelude::*, render::primitives::Aabb};
-use std::sync::Arc;
 use std::marker::PhantomData;
+use std::sync::Arc;
 
 use crate::{
     chunk::{CHUNK_SIZE_F, CHUNK_SIZE_I},
@@ -38,11 +38,19 @@ pub struct ChunkEvent<C> {
 
 impl<C> ChunkEvent<C> {
     pub fn new(chunk_key: IVec3, entity: Entity) -> Self {
-        Self { chunk_key, entity, _marker: PhantomData }
+        Self {
+            chunk_key,
+            entity,
+            _marker: PhantomData,
+        }
     }
 
     pub fn clone(&self) -> Self {
-        Self { chunk_key: self.chunk_key.clone(), entity: self.entity.clone(), _marker: PhantomData }
+        Self {
+            chunk_key: self.chunk_key,
+            entity: self.entity,
+            _marker: PhantomData,
+        }
     }
 }
 

--- a/src/voxel_world.rs
+++ b/src/voxel_world.rs
@@ -329,9 +329,7 @@ impl<'w, C: VoxelWorldConfig> VoxelWorld<'w, C> {
 fn get_hit_normal(vox_pos: IVec3, ray: Ray3d) -> Option<Vec3> {
     let voxel_aabb = Aabb::from_min_max(vox_pos.as_vec3(), vox_pos.as_vec3() + Vec3::ONE);
 
-    let Some((_, normal)) = voxel_aabb.ray_intersection(ray) else {
-        return None;
-    };
+    let (_, normal) = voxel_aabb.ray_intersection(ray)?;
 
     Some(normal)
 }

--- a/src/voxel_world.rs
+++ b/src/voxel_world.rs
@@ -17,7 +17,17 @@ use crate::{
 /// This component is used to mark the Camera that bevy_voxel_world should use to determine
 /// which chunks to spawn and despawn.
 #[derive(Component)]
-pub struct VoxelWorldCamera;
+pub struct VoxelWorldCamera<C> {
+    _marker: PhantomData<C>,
+}
+
+impl<C> Default for VoxelWorldCamera<C> {
+    fn default() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
 
 #[derive(Event)]
 pub struct ChunkEvent<C> {
@@ -225,7 +235,7 @@ impl<'w, C: VoxelWorldConfig> VoxelWorld<'w, C> {
     ///
     /// fn do_raycast(
     ///     voxel_world_raycast: VoxelWorldRaycast<DefaultWorld>,
-    ///     camera_info: Query<(&Camera, &GlobalTransform), With<VoxelWorldCamera>>,
+    ///     camera_info: Query<(&Camera, &GlobalTransform), With<VoxelWorldCamera<DefaultWorld>>>,
     ///     mut cursor_evr: EventReader<CursorMoved>,
     /// ) {
     ///     for ev in cursor_evr.read() {

--- a/src/voxel_world_internal.rs
+++ b/src/voxel_world_internal.rs
@@ -27,8 +27,8 @@ use crate::{
 };
 
 #[derive(SystemParam, Deref)]
-pub struct CameraInfo<'w, 's>(
-    Query<'w, 's, (&'static Camera, &'static GlobalTransform), With<VoxelWorldCamera>>,
+pub struct CameraInfo<'w, 's, C: VoxelWorldConfig>(
+    Query<'w, 's, (&'static Camera, &'static GlobalTransform), With<VoxelWorldCamera<C>>>,
 );
 
 /// Holds a map of modified voxels that will persist between chunk spawn/despawn
@@ -80,7 +80,7 @@ impl<C: VoxelWorldConfig> Internals<C> {
         mut chunk_map_write_buffer: ResMut<ChunkMapInsertBuffer<C>>,
         chunk_map: Res<ChunkMap<C>>,
         configuration: Res<C>,
-        camera_info: CameraInfo,
+        camera_info: CameraInfo<C>,
     ) {
         let (camera, cam_gtf) = camera_info.single();
         let cam_pos = cam_gtf.translation().as_ivec3();
@@ -195,7 +195,7 @@ impl<C: VoxelWorldConfig> Internals<C> {
         mut commands: Commands,
         all_chunks: Query<(&Chunk<C>, Option<&ViewVisibility>)>,
         configuration: Res<C>,
-        camera_info: CameraInfo,
+        camera_info: CameraInfo<C>,
         mut ev_chunk_will_despawn: EventWriter<ChunkWillDespawn<C>>,
     ) {
         let spawning_distance = configuration.spawning_distance() as i32;

--- a/src/voxel_world_internal.rs
+++ b/src/voxel_world_internal.rs
@@ -366,7 +366,7 @@ impl<C: VoxelWorldConfig> Internals<C> {
                 chunk_map_update_buffer.push((
                     chunk.position,
                     chunk_task.chunk_data,
-                    ChunkWillSpawn::<C>::new(chunk_task.position, entity)
+                    ChunkWillSpawn::<C>::new(chunk_task.position, entity),
                 ));
             } else {
                 commands


### PR DESCRIPTION
This allows filtering for specific worlds.

(I think the first two issues are solved now, but feel free to correct me :)
* ~What I am not sure about is, how to handle the clone in ChunkWillSpawn. I am not very experienced with rust, so there may be a cleaner way...~
* ~Also implementing the new for all events using the same code may be done in another way without duplicate code.~


* I am thinking if the VoxelWorldCamera should also have the type parameter, so that you can attach different cameras to different worlds (e.g. for  a split screen multiplayer...)

I already tested it with my https://github.com/aligator/bevy-miner and it seems to work very nice.