### PR TITLE
Root Node & init_root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 assets/.DS_Store
 .VSCodeCounter
+.idea

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -110,6 +110,8 @@ pub trait VoxelWorldConfig: Resource + Default + Clone {
     fn init_custom_materials(&self) -> bool {
         true
     }
+
+    fn init_root(&self, mut _commands: Commands, _root: Entity) {}
 }
 
 #[derive(Resource, Clone, Default)]

--- a/src/voxel_world_internal.rs
+++ b/src/voxel_world_internal.rs
@@ -64,10 +64,12 @@ pub(crate) struct Internals<C>(PhantomData<C>);
 #[derive(Component)]
 pub struct WorldRoot<C>(PhantomData<C>);
 
-impl<C: VoxelWorldConfig> Internals<C> {
+impl<C: VoxelWorldConfig> Internals<C>
+where
+C: VoxelWorldConfig,
+{
     /// Init the resources used internally by bevy_voxel_world
-    pub fn setup(mut commands: Commands) {
-        commands.spawn((WorldRoot::<C>(PhantomData), VisibilityBundle::default(), TransformBundle::default()));
+    pub fn setup(mut commands: Commands, configuration: Res<C>) {
         commands.init_resource::<ChunkMap<C>>();
         commands.init_resource::<ChunkMapInsertBuffer<C>>();
         commands.init_resource::<ChunkMapUpdateBuffer<C>>();
@@ -76,6 +78,10 @@ impl<C: VoxelWorldConfig> Internals<C> {
         commands.init_resource::<MeshCacheInsertBuffer<C>>();
         commands.init_resource::<ModifiedVoxels<C>>();
         commands.init_resource::<VoxelWriteBuffer<C>>();
+        
+        // Create the root node and allow to modify it by the configuration.
+        let world_root = commands.spawn((WorldRoot::<C>(PhantomData), VisibilityBundle::default(), TransformBundle::default())).id();
+        configuration.init_root(commands, world_root)
     }
 
     /// Find and spawn chunks in need of spawning

--- a/src/voxel_world_internal.rs
+++ b/src/voxel_world_internal.rs
@@ -67,7 +67,7 @@ pub struct WorldRoot<C>(PhantomData<C>);
 impl<C: VoxelWorldConfig> Internals<C> {
     /// Init the resources used internally by bevy_voxel_world
     pub fn setup(mut commands: Commands) {
-        commands.spawn(WorldRoot::<C>(PhantomData));
+        commands.spawn((WorldRoot::<C>(PhantomData), VisibilityBundle::default(), TransformBundle::default()));
         commands.init_resource::<ChunkMap<C>>();
         commands.init_resource::<ChunkMapInsertBuffer<C>>();
         commands.init_resource::<ChunkMapUpdateBuffer<C>>();
@@ -89,7 +89,7 @@ impl<C: VoxelWorldConfig> Internals<C> {
     ) {
         // Panic if no root exists as it is already inserted in the setup.
         let world_root = world_root.get_single().unwrap();
-
+    
         let (camera, cam_gtf) = camera_info.single();
         let cam_pos = cam_gtf.translation().as_ivec3();
 
@@ -167,7 +167,9 @@ impl<C: VoxelWorldConfig> Internals<C> {
             let has_chunk = ChunkMap::<C>::contains_chunk(&chunk_position, &chunk_map_read_lock);
 
             if !has_chunk {
-                let chunk = Chunk::<C>::new(chunk_position, commands.entity(world_root).insert(NeedsRemesh).id());
+                let chunk_entity = commands.spawn(NeedsRemesh).id();
+                commands.entity(world_root).add_child(chunk_entity);
+                let chunk = Chunk::<C>::new(chunk_position, chunk_entity);
 
                 chunk_map_write_buffer.push((chunk_position, ChunkData::with_entity(chunk.entity)));
 

--- a/src/voxel_world_internal.rs
+++ b/src/voxel_world_internal.rs
@@ -66,7 +66,7 @@ pub struct WorldRoot<C>(PhantomData<C>);
 
 impl<C: VoxelWorldConfig> Internals<C>
 where
-C: VoxelWorldConfig,
+    C: VoxelWorldConfig,
 {
     /// Init the resources used internally by bevy_voxel_world
     pub fn setup(mut commands: Commands, configuration: Res<C>) {
@@ -78,9 +78,15 @@ C: VoxelWorldConfig,
         commands.init_resource::<MeshCacheInsertBuffer<C>>();
         commands.init_resource::<ModifiedVoxels<C>>();
         commands.init_resource::<VoxelWriteBuffer<C>>();
-        
+
         // Create the root node and allow to modify it by the configuration.
-        let world_root = commands.spawn((WorldRoot::<C>(PhantomData), VisibilityBundle::default(), TransformBundle::default())).id();
+        let world_root = commands
+            .spawn((
+                WorldRoot::<C>(PhantomData),
+                VisibilityBundle::default(),
+                TransformBundle::default(),
+            ))
+            .id();
         configuration.init_root(commands, world_root)
     }
 
@@ -95,7 +101,7 @@ C: VoxelWorldConfig,
     ) {
         // Panic if no root exists as it is already inserted in the setup.
         let world_root = world_root.get_single().unwrap();
-    
+
         let (camera, cam_gtf) = camera_info.single();
         let cam_pos = cam_gtf.translation().as_ivec3();
 


### PR DESCRIPTION
This adds a root node, and the chunks are spawned as children of it.
You can also add a init_root function to the world configuration:
```rust
fn init_root(&self, mut commands: Commands, root: Entity) {
        commands.entity(root).insert((Name::new("physics_world"), Visibility::Hidden));
}
```