### PR TITLE
Expose chunk

### DIFF
--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -183,7 +183,7 @@ impl<C: Send + Sync + 'static> ChunkTask<C> {
     }
 
     /// Generate voxel data for the chunk. The supplied `modified_voxels` map is first checked,
-    /// and where no voxeles are modified, the `voxel_data_fn` is called to get data from the
+    /// and where no voxels are modified, the `voxel_data_fn` is called to get data from the
     /// consumer.
     pub fn generate<F>(&mut self, mut voxel_data_fn: F)
     where
@@ -238,7 +238,7 @@ impl<C: Send + Sync + 'static> ChunkTask<C> {
         self.chunk_data.generate_hash();
     }
 
-    /// Generate a mesh for the chunk based on the currect voxel data
+    /// Generate a mesh for the chunk based on the correct voxel data
     pub fn mesh(&mut self, texture_index_mapper: Arc<dyn Fn(u8) -> [u32; 3] + Send + Sync>) {
         if self.mesh.is_none() && self.chunk_data.voxels.is_some() {
             self.mesh = Some(meshing::generate_chunk_mesh(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,5 +26,9 @@ pub mod rendering {
     pub use crate::voxel_material::VOXEL_TEXTURE_SHADER_HANDLE;
 }
 
+pub mod mesh {
+    pub use crate::meshing::generate_chunk_mesh;
+}
+
 #[cfg(test)]
 mod test;

--- a/src/meshing.rs
+++ b/src/meshing.rs
@@ -24,7 +24,7 @@ use crate::{
 type VoxelArray = Arc<[WorldVoxel; PaddedChunkShape::SIZE as usize]>;
 
 /// Generate a mesh for the given chunks, or None of the chunk is empty
-pub(super) fn generate_chunk_mesh(
+pub fn generate_chunk_mesh(
     voxels: VoxelArray,
     _pos: IVec3,
     texture_index_mapper: Arc<dyn Fn(u8) -> [u32; 3] + Send + Sync>,

--- a/src/voxel_world.rs
+++ b/src/voxel_world.rs
@@ -13,6 +13,7 @@ use crate::{
     voxel::{VoxelAabb, WorldVoxel},
     voxel_world_internal::{get_chunk_voxel_position, ModifiedVoxels, VoxelWriteBuffer},
 };
+use crate::chunk::ChunkData;
 
 /// This component is used to mark the Camera that bevy_voxel_world should use to determine
 /// which chunks to spawn and despawn.
@@ -115,6 +116,12 @@ impl<'w, C: VoxelWorldConfig> VoxelWorld<'w, C> {
     /// the given position.
     pub fn set_voxel(&mut self, position: IVec3, voxel: WorldVoxel) {
         self.voxel_write_buffer.push((position, voxel));
+    }
+
+    pub fn get_chunk(&self, position: IVec3) -> Option<ChunkData> {
+        let chunk_map = self.chunk_map.get_map();
+        let chunk_map_read = chunk_map.read().unwrap();
+        chunk_map_read.get(&position).cloned()
     }
 
     /// Get a sendable closure that can be used to get the voxel at the given position


### PR DESCRIPTION
Exposes the chunk information and also the generate_chunk_mesh function, useful for collider generation.
As I am not sure yet how to expose this the best way, it is a WIP for now...