### PR TITLE
Force ahash to 0.7.8^

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom 0.2.10",
  "once_cell",
@@ -1031,6 +1031,7 @@ dependencies = [
 name = "bevy_voxel_world"
 version = "0.6.0"
 dependencies = [
+ "ahash 0.7.8",
  "bevy",
  "block-mesh",
  "futures-lite 2.2.0",
@@ -3673,7 +3674,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 dependencies = [
- "ahash 0.7.7",
+ "ahash 0.7.8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ block-mesh = "0.2.0"
 ndshape = "0.3.0"
 futures-lite = "2.0.0"
 rand = "0.8.5"
+ahash = "0.7.8"
 weak-table = { version = "0.3.2", features = ["ahash"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Rather than relying on an older 0.7.x from weak-table to fix nightly build error "unknown feature stdsimd"