### PR TITLE
Fix ray_cast example panicking at startup

### DIFF
--- a/examples/ray_cast.rs
+++ b/examples/ray_cast.rs
@@ -1,5 +1,4 @@
 use bevy::prelude::*;
-use bevy::render::MainWorld;
 use bevy_voxel_world::prelude::*;
 use std::sync::Arc;
 
@@ -68,7 +67,7 @@ fn setup(
             ..default()
         },
         // This tells bevy_voxel_world to use this cameras transform to calculate spawning area
-        VoxelWorldCamera::<MainWorld>::default(),
+        VoxelWorldCamera::<MyMainWorld>::default(),
     ));
 
     // light
@@ -107,7 +106,7 @@ fn create_voxel_scene(mut voxel_world: VoxelWorld<MyMainWorld>) {
 
 fn update_cursor_cube(
     voxel_world_raycast: VoxelWorld<MyMainWorld>,
-    camera_info: Query<(&Camera, &GlobalTransform), With<VoxelWorldCamera<MainWorld>>>,
+    camera_info: Query<(&Camera, &GlobalTransform), With<VoxelWorldCamera<MyMainWorld>>>,
     mut cursor_evr: EventReader<CursorMoved>,
     mut cursor_cube: Query<(&mut Transform, &mut CursorCube)>,
 ) {


### PR DESCRIPTION
Fix example code template camera tag to be MyMainWorld rather than MainWorld (which is what is used when registering `VoxelWorldPlugin<MyMainWorld>`)