### PR TITLE
Add fast voxel grid line traversal algorithm and cartesian helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,6 +1038,7 @@ dependencies = [
  "ndshape",
  "noise",
  "rand 0.8.5",
+ "smooth-bevy-cameras",
  "weak-table",
 ]
 
@@ -3287,6 +3288,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "smooth-bevy-cameras"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd87c41a0df786a4f89ef25506520d5b7d89baa295c7f06d084913e09863a32"
+dependencies = [
+ "approx",
+ "bevy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,23 @@ futures-lite = "2.0.0"
 rand = "0.8.5"
 ahash = "0.7.8"
 weak-table = { version = "0.3.2", features = ["ahash"] }
+noise = { version = "0.8.2", optional = true }
+smooth-bevy-cameras = { version = "0.11.0", optional = true }
 
 [dev-dependencies]
-noise = "0.8.2"
+
+[[example]]
+name = "fast_traversal_ray"
+required-features = ["smooth-bevy-cameras"]
+
+[[example]]
+name = "bombs"
+required-features = ["noise"]
+
+[[example]]
+name = "noise_terrain"
+required-features = ["noise"]
+
+[[example]]
+name = "multiple_worlds"
+required-features = ["noise"]

--- a/examples/fast_traversal_ray.rs
+++ b/examples/fast_traversal_ray.rs
@@ -156,8 +156,7 @@ fn draw_trace(trace: Res<VoxelTrace>, mut gizmos: Gizmos) {
                 Color::PINK,
             );
 
-            if face != VoxelFace::None {
-                let normal: Vec3 = face.into();
+            if let Ok(normal) = face.try_into() {
                 gizmos.circle(
                     voxel_center + (normal * VOXEL_SIZE / 2.),
                     Direction3d::new(normal).unwrap(),

--- a/examples/fast_traversal_ray.rs
+++ b/examples/fast_traversal_ray.rs
@@ -144,10 +144,7 @@ fn update_cursor_cube(
     }
 }
 
-fn draw_trace(
-    trace: Res<VoxelTrace>,
-    mut gizmos: Gizmos,
-) {
+fn draw_trace(trace: Res<VoxelTrace>, mut gizmos: Gizmos) {
     if let Some(trace_start) = trace.start {
         gizmos.line(trace_start, trace.end, Color::RED);
 
@@ -165,13 +162,15 @@ fn draw_trace(
                     voxel_center + (normal * VOXEL_SIZE / 2.),
                     Direction3d::new(normal).unwrap(),
                     0.8 * VOXEL_SIZE / 2.,
-                    Color::RED.with_a(0.5));
+                    Color::RED.with_a(0.5),
+                );
 
                 gizmos.sphere(
                     trace_start + (trace.end - trace_start) * time,
                     Quat::IDENTITY,
                     0.1,
-                    Color::BLACK);
+                    Color::BLACK,
+                );
             }
 
             // Keep drawing until trace has finished visiting all voxels along the way
@@ -194,13 +193,17 @@ fn inputs(
         let cursor = cursor_cube.single();
         let trace_end = cursor.voxel_pos.as_vec3() + Vec3::splat(VOXEL_SIZE / 2.);
 
-        voxel_line_traversal(trace.start.unwrap(), trace_end, |voxel_coords, _time, _face| {
-            voxel_world.set_voxel(voxel_coords, WorldVoxel::Air);
+        voxel_line_traversal(
+            trace.start.unwrap(),
+            trace_end,
+            |voxel_coords, _time, _face| {
+                voxel_world.set_voxel(voxel_coords, WorldVoxel::Air);
 
-            // Keep erasing until trace has finished visiting all voxels along the way
-            const NEVER_STOP: bool = true;
-            NEVER_STOP
-        });
+                // Keep erasing until trace has finished visiting all voxels along the way
+                const NEVER_STOP: bool = true;
+                NEVER_STOP
+            },
+        );
     }
 
     if buttons.just_pressed(MouseButton::Left) {

--- a/examples/fast_traversal_ray.rs
+++ b/examples/fast_traversal_ray.rs
@@ -1,0 +1,216 @@
+use std::sync::Arc;
+
+use bevy::prelude::*;
+
+use bevy_voxel_world::prelude::*;
+use bevy_voxel_world::traversal_alg::*;
+
+// Declare materials as consts for convenience
+const SNOWY_BRICK: u8 = 0;
+const FULL_BRICK: u8 = 1;
+const GRASS: u8 = 2;
+
+#[derive(Resource, Clone, Default)]
+struct MyMainWorld;
+
+#[derive(Resource, Clone, Default)]
+struct VoxelTrace {
+    start: Option<Vec3>,
+    end: Vec3,
+}
+
+impl VoxelWorldConfig for MyMainWorld {
+    fn texture_index_mapper(&self) -> Arc<dyn Fn(u8) -> [u32; 3] + Send + Sync> {
+        Arc::new(|vox_mat: u8| match vox_mat {
+            SNOWY_BRICK => [0, 1, 2],
+            FULL_BRICK => [2, 2, 2],
+            _ => [3, 3, 3],
+        })
+    }
+
+    fn voxel_texture(&self) -> Option<(String, u32)> {
+        Some(("example_voxel_texture.png".into(), 4))
+    }
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        // We can specify a custom texture when initializing the plugin.
+        // This should just be a path to an image in your assets folder.
+        .add_plugins(VoxelWorldPlugin::with_config(MyMainWorld))
+        .init_resource::<VoxelTrace>()
+        .add_systems(Startup, (setup, create_voxel_scene))
+        .add_systems(Update, (inputs, update_cursor_cube, draw_trace))
+        .run();
+}
+
+#[derive(Component)]
+struct CursorCube {
+    voxel_pos: IVec3,
+    voxel_mat: u8,
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // Cursor cube
+    commands.spawn((
+        PbrBundle {
+            mesh: meshes.add(Mesh::from(Cuboid {
+                half_size: Vec3::splat(0.5),
+            })),
+            material: materials.add(Color::rgba_u8(124, 144, 255, 128)),
+            transform: Transform::from_xyz(0.0, -10.0, 0.0),
+            ..default()
+        },
+        CursorCube {
+            voxel_pos: IVec3::new(0, -10, 0),
+            voxel_mat: FULL_BRICK,
+        },
+    ));
+
+    // Camera
+    commands.spawn((
+        Camera3dBundle {
+            transform: Transform::from_xyz(10.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+            ..default()
+        },
+        // This tells bevy_voxel_world to use this cameras transform to calculate spawning area
+        VoxelWorldCamera::<MyMainWorld>::default(),
+    ));
+
+    // light
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            shadows_enabled: true,
+            ..default()
+        },
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..default()
+    });
+}
+
+fn create_voxel_scene(mut voxel_world: VoxelWorld<MyMainWorld>) {
+    // Then we can use the `u8` consts to specify the type of voxel
+
+    // 20 by 20 floor
+    for x in -10..10 {
+        for z in -10..10 {
+            voxel_world.set_voxel(IVec3::new(x, -1, z), WorldVoxel::Solid(GRASS));
+            // Grassy floor
+        }
+    }
+
+    // Some bricks
+    voxel_world.set_voxel(IVec3::new(0, 0, 0), WorldVoxel::Solid(SNOWY_BRICK));
+    voxel_world.set_voxel(IVec3::new(1, 0, 0), WorldVoxel::Solid(SNOWY_BRICK));
+    voxel_world.set_voxel(IVec3::new(0, 0, 1), WorldVoxel::Solid(SNOWY_BRICK));
+    voxel_world.set_voxel(IVec3::new(0, 0, -1), WorldVoxel::Solid(SNOWY_BRICK));
+    voxel_world.set_voxel(IVec3::new(-1, 0, 0), WorldVoxel::Solid(FULL_BRICK));
+    voxel_world.set_voxel(IVec3::new(-2, 0, 0), WorldVoxel::Solid(FULL_BRICK));
+    voxel_world.set_voxel(IVec3::new(-1, 1, 0), WorldVoxel::Solid(SNOWY_BRICK));
+    voxel_world.set_voxel(IVec3::new(-2, 1, 0), WorldVoxel::Solid(SNOWY_BRICK));
+    voxel_world.set_voxel(IVec3::new(0, 1, 0), WorldVoxel::Solid(SNOWY_BRICK));
+}
+
+fn update_cursor_cube(
+    voxel_world_raycast: VoxelWorld<MyMainWorld>,
+    mut trace: ResMut<VoxelTrace>,
+    camera_info: Query<(&Camera, &GlobalTransform), With<VoxelWorldCamera<MyMainWorld>>>,
+    mut cursor_evr: EventReader<CursorMoved>,
+    mut cursor_cube: Query<(&mut Transform, &mut CursorCube)>,
+) {
+    for ev in cursor_evr.read() {
+        // Get a ray from the cursor position into the world
+        let (camera, cam_gtf) = camera_info.single();
+        let Some(ray) = camera.viewport_to_world(cam_gtf, ev.position) else {
+            return;
+        };
+
+        if let Some(result) = voxel_world_raycast.raycast(ray, &|(_pos, _vox)| true) {
+            let (mut transform, mut cursor_cube) = cursor_cube.single_mut();
+
+            // Move the cursor cube to the position of the voxel we hit
+            let voxel_pos = result.position + result.normal;
+            transform.translation = voxel_pos + Vec3::splat(VOXEL_SIZE / 2.);
+            cursor_cube.voxel_pos = voxel_pos.as_ivec3();
+
+            // Update current trace end to the cursor cube position
+            trace.end = transform.translation;
+        }
+    }
+}
+
+fn draw_trace(
+    trace: Res<VoxelTrace>,
+    mut gizmos: Gizmos,
+) {
+    if let Some(trace_start) = trace.start {
+        gizmos.line(trace_start, trace.end, Color::RED);
+
+        voxel_line_traversal(trace_start, trace.end, |voxel_coord, time, face| {
+            let voxel_center = voxel_coord.as_vec3() + Vec3::splat(VOXEL_SIZE / 2.);
+
+            gizmos.cuboid(
+                Transform::from_translation(voxel_center).with_scale(Vec3::splat(VOXEL_SIZE)),
+                Color::PINK,
+            );
+
+            if face != VoxelFace::None {
+                let normal: Vec3 = face.into();
+                gizmos.circle(
+                    voxel_center + (normal * VOXEL_SIZE / 2.),
+                    Direction3d::new(normal).unwrap(),
+                    0.8 * VOXEL_SIZE / 2.,
+                    Color::RED.with_a(0.5));
+
+                gizmos.sphere(
+                    trace_start + (trace.end - trace_start) * time,
+                    Quat::IDENTITY,
+                    0.1,
+                    Color::BLACK);
+            }
+
+            // Keep drawing until trace has finished visiting all voxels along the way
+            const NEVER_STOP: bool = true;
+            NEVER_STOP
+        });
+    }
+}
+
+fn inputs(
+    buttons: Res<ButtonInput<MouseButton>>,
+    keys: Res<ButtonInput<KeyCode>>,
+    mut voxel_world: VoxelWorld<MyMainWorld>,
+    mut trace: ResMut<VoxelTrace>,
+    cursor_cube: Query<&CursorCube>,
+) {
+    if keys.just_released(KeyCode::ControlLeft) {
+        trace.start = None;
+    } else if keys.pressed(KeyCode::ControlLeft) && keys.just_pressed(KeyCode::KeyE) {
+        let cursor = cursor_cube.single();
+        let trace_end = cursor.voxel_pos.as_vec3() + Vec3::splat(VOXEL_SIZE / 2.);
+
+        voxel_line_traversal(trace.start.unwrap(), trace_end, |voxel_coords, _time, _face| {
+            voxel_world.set_voxel(voxel_coords, WorldVoxel::Air);
+
+            // Keep erasing until trace has finished visiting all voxels along the way
+            const NEVER_STOP: bool = true;
+            NEVER_STOP
+        });
+    }
+
+    if buttons.just_pressed(MouseButton::Left) {
+        let cursor = cursor_cube.single();
+
+        if keys.pressed(KeyCode::ControlLeft) {
+            trace.start = Some(cursor.voxel_pos.as_vec3() + Vec3::splat(VOXEL_SIZE / 2.))
+        } else {
+            let vox_pos = cursor.voxel_pos;
+            voxel_world.set_voxel(vox_pos, WorldVoxel::Solid(cursor.voxel_mat));
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod meshing;
 mod plugin;
 mod voxel;
 mod voxel_material;
+mod voxel_traversal;
 mod voxel_world;
 mod voxel_world_internal;
 
@@ -15,7 +16,7 @@ pub mod prelude {
     pub use crate::configuration::*;
     pub use crate::debug::{ChunkAabbGizmo, VoxelWorldGizmoPlugin};
     pub use crate::plugin::VoxelWorldPlugin;
-    pub use crate::voxel::WorldVoxel;
+    pub use crate::voxel::{VOXEL_SIZE, VoxelFace, WorldVoxel};
     pub use crate::voxel_world::{ChunkWillDespawn, ChunkWillRemesh, ChunkWillSpawn};
     pub use crate::voxel_world::{VoxelRaycastResult, VoxelWorld, VoxelWorldCamera};
 }
@@ -24,6 +25,10 @@ pub mod rendering {
     pub use crate::plugin::VoxelWorldMaterialHandle;
     pub use crate::voxel_material::vertex_layout;
     pub use crate::voxel_material::VOXEL_TEXTURE_SHADER_HANDLE;
+}
+
+pub mod traversal_alg {
+    pub use crate::voxel_traversal::*;
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub mod prelude {
     pub use crate::configuration::*;
     pub use crate::debug::{ChunkAabbGizmo, VoxelWorldGizmoPlugin};
     pub use crate::plugin::VoxelWorldPlugin;
-    pub use crate::voxel::{VOXEL_SIZE, VoxelFace, WorldVoxel};
+    pub use crate::voxel::{VoxelFace, WorldVoxel, VOXEL_SIZE};
     pub use crate::voxel_world::{ChunkWillDespawn, ChunkWillRemesh, ChunkWillSpawn};
     pub use crate::voxel_world::{VoxelRaycastResult, VoxelWorld, VoxelWorldCamera};
 }

--- a/src/voxel.rs
+++ b/src/voxel.rs
@@ -1,6 +1,8 @@
 use bevy::{prelude::*, render::primitives::Aabb};
 use block_mesh::{MergeVoxel, Voxel, VoxelVisibility};
 
+pub const VOXEL_SIZE: f32 = 1.;
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 pub enum WorldVoxel {
     #[default]
@@ -40,6 +42,31 @@ impl MergeVoxel for WorldVoxel {
         match self {
             WorldVoxel::Solid(v) => *v,
             _ => 0,
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Copy, Clone)]
+pub enum VoxelFace {
+    None,
+    Bottom,
+    Top,
+    Left,
+    Right,
+    Back,
+    Forward,
+}
+
+impl From<VoxelFace> for Vec3 {
+    fn from(face: VoxelFace) -> Self {
+        match face {
+            VoxelFace::None => panic!("VoxelFace::None has no normal"),
+            VoxelFace::Bottom => -Vec3::Y,
+            VoxelFace::Top => Vec3::Y,
+            VoxelFace::Left => -Vec3::X,
+            VoxelFace::Right => Vec3::X,
+            VoxelFace::Back => -Vec3::Z,
+            VoxelFace::Forward => Vec3::Z,
         }
     }
 }

--- a/src/voxel.rs
+++ b/src/voxel.rs
@@ -46,7 +46,7 @@ impl MergeVoxel for WorldVoxel {
     }
 }
 
-#[derive(Eq, PartialEq, Copy, Clone)]
+#[derive(Eq, PartialEq, Copy, Clone, Debug)]
 pub enum VoxelFace {
     None,
     Bottom,
@@ -57,16 +57,18 @@ pub enum VoxelFace {
     Forward,
 }
 
-impl From<VoxelFace> for Vec3 {
-    fn from(face: VoxelFace) -> Self {
-        match face {
-            VoxelFace::None => panic!("VoxelFace::None has no normal"),
-            VoxelFace::Bottom => -Vec3::Y,
-            VoxelFace::Top => Vec3::Y,
-            VoxelFace::Left => -Vec3::X,
-            VoxelFace::Right => Vec3::X,
-            VoxelFace::Back => -Vec3::Z,
-            VoxelFace::Forward => Vec3::Z,
+impl TryFrom<VoxelFace> for Vec3 {
+    type Error = ();
+
+    fn try_from(value: VoxelFace) -> Result<Self, Self::Error> {
+        match value {
+            VoxelFace::None => Err(()),
+            VoxelFace::Bottom => Ok(-Vec3::Y),
+            VoxelFace::Top => Ok(Vec3::Y),
+            VoxelFace::Left => Ok(-Vec3::X),
+            VoxelFace::Right => Ok(Vec3::X),
+            VoxelFace::Back => Ok(-Vec3::Z),
+            VoxelFace::Forward => Ok(Vec3::Z),
         }
     }
 }

--- a/src/voxel_traversal.rs
+++ b/src/voxel_traversal.rs
@@ -1,0 +1,173 @@
+use bevy::math::{IVec3, Vec3};
+use bevy::prelude::{Struct, FromReflect};
+use crate::voxel::{VOXEL_SIZE, VoxelFace};
+
+/// Traverses the voxel grid along a fixed, grid-aligned direction, applying `visit_voxel` to
+/// every voxel along the way (from `start` included to `end` **excluded**).
+pub fn voxel_cartesian_traversal<F: FnMut(IVec3) -> bool + Sized>(
+    start: IVec3,
+    end: IVec3,
+    mut visit_voxel: F,
+) {
+    let delta = end - start;
+
+    // Make sure one and only one component of the direction we follow is non-zero
+    debug_assert!(delta.signum().abs().iter_fields().map(|f| { i32::from_reflect(f).unwrap() }).sum::<i32>() == 1);
+
+    let distance = delta.abs().max_element();
+    let direction = delta / distance;
+
+    for d in 0..distance {
+        let voxel_coords = start + direction * d;
+        if !visit_voxel(voxel_coords) {
+            break;
+        }
+    }
+}
+
+/// Fast voxel traversal between arbitrary world locations. Given two world positions, visits all
+/// voxels along the ray from `start` to `end` (included). If you want to traverse the grid along
+/// a cardinal dimension, use voxel_cartesian_traversal instead.
+///
+/// Specify a function or closure for `visit_voxel`, which will get executed for every voxel
+/// traversed by the ray. `visit_voxel` will be called with:
+/// - The current voxel coordinates on the grid
+/// - The normalized time `t` along the ray at the moment the ray intersects with the current
+/// voxel (such that `IntersectionPoint = t * (end - start)`)
+/// - The face through which the voxel was entered by the ray
+///
+/// # Example
+/// ```
+/// use bevy::prelude::*;
+/// use bevy_voxel_world::prelude::*;
+/// use bevy_voxel_world::traversal_alg::*;
+///
+/// fn draw_trace(trace_start: Vec3, trace_end: Vec3, mut gizmos: Gizmos) {
+///     gizmos.line(trace_start, trace_end, Color::RED);
+///
+///     voxel_line_traversal(trace_start, trace_end, |voxel_coord, time, face| {
+///         let voxel_center = voxel_coord.as_vec3() + Vec3::splat(VOXEL_SIZE / 2.);
+///
+///         // Draw a debug cube for the currently visited voxel
+///         gizmos.cuboid(
+///             Transform::from_translation(voxel_center).with_scale(Vec3::splat(VOXEL_SIZE)),
+///             Color::PINK,
+///         );
+///
+///         // Draw a debug dot where the ray entered this voxel
+///         gizmos.sphere(
+///             trace_start + (trace_end - trace_start) * time,
+///             Quat::IDENTITY,
+///             0.1,
+///             Color::BLACK);
+///
+///         // If this is not the very first voxel visited (ie, the one including `start`), draw
+///         // a debug circle on the face through which the trace entered the current voxel
+///         if face != VoxelFace::None {
+///             let entered_face_normal: Vec3 = face.into();
+///             gizmos.circle(
+///                 voxel_center + (entered_face_normal * VOXEL_SIZE / 2.),
+///                 Direction3d::new(entered_face_normal).unwrap(),
+///                 0.8 * VOXEL_SIZE / 2.,
+///                 Color::RED.with_a(0.5));
+///         }
+///
+///         // Keep drawing until trace has finished visiting all voxels along the way
+///         const NEVER_STOP: bool = true;
+///         NEVER_STOP
+///     });
+/// }
+/// ```
+///
+/// # Note
+/// This algorithm visits all voxels along a ray, using the uniform partitioned grid to determine
+/// what fixed increments of time over the ray are necessary to iterate each voxel exactly once.
+/// This is an implementation of J. Amanatides, A. Woo, "A Fast Voxel Traversal Algorithm for Ray
+/// Tracing", accessible online at http://www.cse.yorku.ca/~amana/research/grid.pdf
+pub fn voxel_line_traversal<F: FnMut(IVec3, f32, VoxelFace) -> bool + Sized>(
+    start: Vec3,
+    end: Vec3,
+    mut visit_voxel: F,
+) {
+    let ray = end - start;
+    let end_t = ray.length();
+    let ray_dir = ray / end_t;
+    let r_ray_dir = ray_dir.recip();
+    let delta_t = (VOXEL_SIZE * r_ray_dir).abs();
+
+    let step = ray_dir.signum().as_ivec3();
+
+    let start_voxel = start.floor().as_ivec3();
+    let end_voxel = end.floor().as_ivec3();
+
+    let mut voxel = start_voxel;
+    let mut max_t = Vec3::ZERO;
+
+    max_t.x = if step.x == 0 {
+        end_t
+    } else {
+        let o = if step.x > 0 { 1 } else { 0 };
+        let plane = (start_voxel.x + o) as f32 * VOXEL_SIZE;
+        (plane - start.x) * r_ray_dir.x
+    };
+
+    max_t.y = if step.y == 0 {
+        end_t
+    } else {
+        let o = if step.y > 0 { 1 } else { 0 };
+        let plane = (start_voxel.y + o) as f32 * VOXEL_SIZE;
+        (plane - start.y) * r_ray_dir.y
+    };
+
+    max_t.z = if step.z == 0 {
+        end_t
+    } else {
+        let o = if step.z > 0 { 1 } else { 0 };
+        let plane = (start_voxel.z + o) as f32 * VOXEL_SIZE;
+        (plane - start.z) * r_ray_dir.z
+    };
+
+    let r_end_t = 1. / end_t;
+    let mut time = max_t.min_element() * r_end_t;
+    let mut face = VoxelFace::None;
+
+    let out_of_bounds = end_voxel + step;
+    let mut reached_end = voxel == end_voxel;
+    let mut keep_going = visit_voxel(voxel, time, face);
+
+    let x_face = if step.x > 0 { VoxelFace::Left } else { VoxelFace::Right };
+    let y_face = if step.y > 0 { VoxelFace::Bottom } else { VoxelFace::Top };
+    let z_face = if step.z > 0 { VoxelFace::Back } else { VoxelFace::Forward };
+
+    while keep_going && !reached_end {
+        if max_t.x < max_t.y && max_t.x < max_t.z {
+            time = max_t.x * r_end_t;
+            face = x_face;
+
+            voxel.x += step.x;
+            max_t.x += delta_t.x;
+
+            reached_end = voxel.x == out_of_bounds.x;
+        } else if max_t.y < max_t.z {
+            time = max_t.y * r_end_t;
+            face = y_face;
+
+            voxel.y += step.y;
+            max_t.y += delta_t.y;
+
+            reached_end = voxel.y == out_of_bounds.y;
+        } else {
+            time = max_t.z * r_end_t;
+            face = z_face;
+
+            voxel.z += step.z;
+            max_t.z += delta_t.z;
+
+            reached_end = voxel.z == out_of_bounds.z;
+        }
+
+        if !reached_end {
+            keep_going = visit_voxel(voxel, time, face);
+        }
+    }
+}

--- a/src/voxel_traversal.rs
+++ b/src/voxel_traversal.rs
@@ -71,8 +71,7 @@ pub fn voxel_cartesian_traversal<F: FnMut(IVec3) -> bool + Sized>(
 ///
 ///         // If this is not the very first voxel visited (ie, the one including `start`), draw
 ///         // a debug circle on the face through which the trace entered the current voxel
-///         if face != VoxelFace::None {
-///             let entered_face_normal: Vec3 = face.into();
+///         if let Ok(entered_face_normal) = face.try_into() {
 ///             gizmos.circle(
 ///                 voxel_center + (entered_face_normal * VOXEL_SIZE / 2.),
 ///                 Direction3d::new(entered_face_normal).unwrap(),

--- a/src/voxel_traversal.rs
+++ b/src/voxel_traversal.rs
@@ -1,6 +1,6 @@
+use crate::voxel::{VoxelFace, VOXEL_SIZE};
 use bevy::math::{IVec3, Vec3};
-use bevy::prelude::{Struct, FromReflect};
-use crate::voxel::{VOXEL_SIZE, VoxelFace};
+use bevy::prelude::{FromReflect, Struct};
 
 /// Traverses the voxel grid along a fixed, grid-aligned direction, applying `visit_voxel` to
 /// every voxel along the way (from `start` included to `end` **excluded**).
@@ -12,7 +12,15 @@ pub fn voxel_cartesian_traversal<F: FnMut(IVec3) -> bool + Sized>(
     let delta = end - start;
 
     // Make sure one and only one component of the direction we follow is non-zero
-    debug_assert!(delta.signum().abs().iter_fields().map(|f| { i32::from_reflect(f).unwrap() }).sum::<i32>() == 1);
+    debug_assert!(
+        delta
+            .signum()
+            .abs()
+            .iter_fields()
+            .map(|f| { i32::from_reflect(f).unwrap() })
+            .sum::<i32>()
+            == 1
+    );
 
     let distance = delta.abs().max_element();
     let direction = delta / distance;
@@ -135,9 +143,21 @@ pub fn voxel_line_traversal<F: FnMut(IVec3, f32, VoxelFace) -> bool + Sized>(
     let mut reached_end = voxel == end_voxel;
     let mut keep_going = visit_voxel(voxel, time, face);
 
-    let x_face = if step.x > 0 { VoxelFace::Left } else { VoxelFace::Right };
-    let y_face = if step.y > 0 { VoxelFace::Bottom } else { VoxelFace::Top };
-    let z_face = if step.z > 0 { VoxelFace::Back } else { VoxelFace::Forward };
+    let x_face = if step.x > 0 {
+        VoxelFace::Left
+    } else {
+        VoxelFace::Right
+    };
+    let y_face = if step.y > 0 {
+        VoxelFace::Bottom
+    } else {
+        VoxelFace::Top
+    };
+    let z_face = if step.z > 0 {
+        VoxelFace::Back
+    } else {
+        VoxelFace::Forward
+    };
 
     while keep_going && !reached_end {
         if max_t.x < max_t.y && max_t.x < max_t.z {


### PR DESCRIPTION
+ Added `voxel_line_traversal` and `voxel_cartesian_traversal` for versatile and fast traversal of the voxel grid
+ Created a new bevy_voxel_world::traversal_alg module to make it easy for crate users to import those algorithms
+ Added VoxelFace enum to represent the face of a voxel, automatically imported by the prelude
+ Added VOXEL_SIZE constant (because I was uncomfortable implicitly using the fact that voxels are unit-sized)
+ Added an example showing how to use and debug voxel traces