### PR TITLE
Apply fix for macOS crash in multiple_worlds example

### DIFF
--- a/examples/multiple_worlds.rs
+++ b/examples/multiple_worlds.rs
@@ -6,7 +6,7 @@ use bevy::{
     render::{
         mesh::MeshVertexBufferLayoutRef,
         render_resource::{
-            AsBindGroup, RenderPipelineDescriptor, ShaderRef, SpecializedMeshPipelineError,
+            AsBindGroup, RenderPipelineDescriptor, ShaderDefVal, ShaderRef, SpecializedMeshPipelineError,
         },
     },
     utils::HashMap,
@@ -189,6 +189,14 @@ impl Material for CustomVoxelMaterial {
         layout: &MeshVertexBufferLayoutRef,
         _key: MaterialPipelineKey<Self>,
     ) -> Result<(), SpecializedMeshPipelineError> {
+        if descriptor
+            .vertex
+            .shader_defs
+            .contains(&ShaderDefVal::Bool("PREPASS_PIPELINE".into(), true))
+        {
+            return Ok(());
+        }
+
         // Use `vertex_layout()` from `bevy_voxel_world` to get the correct vertex layout
         let vertex_layout = layout.0.get_layout(&vertex_layout())?;
         descriptor.vertex.buffers = vec![vertex_layout];


### PR DESCRIPTION
By doing the same fix as in commit fba3520 in multiple_worlds.rs, we avoid the issue with a crash for bevy 0.15 on macOS.

This should fix issue #48 