### PR TITLE
Add get_run_if_condition that gives you control over when systems run

### DIFF
--- a/examples/run_if.rs
+++ b/examples/run_if.rs
@@ -1,0 +1,140 @@
+use std::{sync::Arc, time::Duration};
+
+use bevy::{pbr::CascadeShadowConfigBuilder, prelude::*};
+use bevy_voxel_world::prelude::*;
+
+// Pretend we are loading for this duraction
+const SIMULATED_LOADING_DURATION_MILLIS: u64 = 2000;
+
+const SURFACE_Y: i32 = 0;
+const MAP_DIMENSION: i32 = 128;
+const MAP_HALF_DIMENSION: i32 = MAP_DIMENSION / 2;
+
+#[derive(States, Hash, Clone, PartialEq, Eq, Debug, Default)]
+pub enum LoadingState {
+    #[default]
+    Loading,
+    Ready,
+}
+
+/// This timer will simulate the time it takes to load the game before generating any voxels
+#[derive(Resource)]
+struct SimulatedLoadingTimer(Timer);
+
+#[derive(Resource, Clone, Default)]
+struct MainWorld;
+
+impl VoxelWorldConfig for MainWorld {
+    type MaterialIndex = u8;
+    type ChunkUserBundle = ();
+
+    fn spawning_distance(&self) -> u32 {
+        16
+    }
+
+    fn voxel_lookup_delegate(&self) -> VoxelLookupDelegate<Self::MaterialIndex> {
+        Box::new(move |_chunk_pos| get_voxel_fn())
+    }
+
+    // Key element to this example: this defers execution of any
+    // bevy_voxel_world systems until after this condition evaluates to true
+    fn get_run_if_condition(&self) -> impl Condition<()> {
+        in_state(LoadingState::Ready)
+    }
+
+    fn texture_index_mapper(
+        &self,
+    ) -> Arc<dyn Fn(Self::MaterialIndex) -> [u32; 3] + Send + Sync> {
+        Arc::new(|mat| match mat {
+            0 => [0, 0, 0],
+            1 => [1, 1, 1],
+            2 => [2, 2, 2],
+            3 => [3, 3, 3],
+            _ => [0, 0, 0],
+        })
+    }
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        // Initialize a loading state that we will wait on
+        .init_state::<LoadingState>()
+        // Setup a timer that we'll use to pretend we are loading
+        .insert_resource(SimulatedLoadingTimer(Timer::new(
+            Duration::from_millis(SIMULATED_LOADING_DURATION_MILLIS),
+            TimerMode::Once,
+        )))
+        .add_plugins(VoxelWorldPlugin::with_config(MainWorld))
+        .add_systems(Startup, setup)
+        .add_systems(Update, move_camera)
+        .add_systems(Update, simulate_loading_duration)
+        .run();
+}
+
+fn simulate_loading_duration(
+    time: Res<Time>,
+    mut timer: ResMut<SimulatedLoadingTimer>,
+    mut next_state: ResMut<NextState<LoadingState>>,
+) {
+    timer.0.tick(time.delta());
+
+    if timer.0.finished() {
+        next_state.set(LoadingState::Ready);
+    }
+}
+
+fn setup(mut commands: Commands) {
+    // camera
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-200.0, 180.0, -200.0).looking_at(Vec3::ZERO, Vec3::Y),
+        // This tells bevy_voxel_world to use this cameras transform to calculate spawning area
+        VoxelWorldCamera::<MainWorld>::default(),
+    ));
+
+    // Sun
+    let cascade_shadow_config = CascadeShadowConfigBuilder { ..default() }.build();
+    commands.spawn((
+        DirectionalLight {
+            color: Color::srgb(0.98, 0.95, 0.82),
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::from_xyz(0.0, 0.0, 0.0)
+            .looking_at(Vec3::new(-0.15, -0.1, 0.15), Vec3::Y),
+        cascade_shadow_config,
+    ));
+
+    // Ambient light, same color as sun
+    commands.insert_resource(AmbientLight {
+        color: Color::srgb(0.98, 0.95, 0.82),
+        brightness: 100.0,
+        affects_lightmapped_meshes: true,
+    });
+}
+
+fn get_voxel_fn() -> Box<dyn FnMut(IVec3) -> WorldVoxel + Send + Sync> {
+    Box::new(move |pos: IVec3| {
+        if pos.y == SURFACE_Y {
+            let tile_x = pos.x + MAP_HALF_DIMENSION;
+            let tile_z = pos.z + MAP_HALF_DIMENSION;
+
+            let material_index = if (tile_x + tile_z) % 2 == 0 { 0 } else { 1 };
+            WorldVoxel::Solid(material_index)
+        } else {
+            WorldVoxel::Air
+        }
+    })
+}
+
+fn move_camera(
+    time: Res<Time>,
+    mut cam_transform: Query<&mut Transform, With<VoxelWorldCamera<MainWorld>>>,
+) {
+    let Ok(mut transform) = cam_transform.get_single_mut() else {
+        return;
+    };
+    transform.translation.x += time.delta_secs() * 30.0;
+    transform.translation.z += time.delta_secs() * 60.0;
+}

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -56,6 +56,12 @@ pub trait VoxelWorldConfig: Resource + Default + Clone {
     /// If you are not using this feature, you can set this to `()`.
     type ChunkUserBundle: Bundle + Clone;
 
+    /// Condition to evaluate before running any voxel systems. This allows you
+    /// to defer execution of bevy_voxel_world systems.
+    fn get_run_if_condition(&self) -> impl Condition<()> {
+        IntoSystem::into_system(|| true)
+    }
+
     /// Distance in chunks to spawn chunks around the camera
     fn spawning_distance(&self) -> u32 {
         10

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -118,7 +118,8 @@ where
                         ),
                     )
                         .chain(),
-                ),
+                )
+                    .run_if(self.config.get_run_if_condition()),
             )
             .add_event::<ChunkWillSpawn<C>>()
             .add_event::<ChunkWillDespawn<C>>()


### PR DESCRIPTION
Hey! Huge fan of this crate. Wanted to suggest a change.

One caveate, I'm having a lot of trouble fighting with Rust's type system (I'm learning still). So this does not build yet. I go into more detail on that at the bottom of this description.

# Problem
I would like to spend time in my application generating a world before any voxel chunks are generated. 

# Attempts to solve this using the existing API
 - `chunk_meshing_delegate` runs on a background thread, so conceivably I could block on this until the game is loaded. Unfortunately, the `voxel_lookup_delegate` is called on a main thread, and will be called before I block the `chunk_meshing_delegate`, so I can't pause the application to determine where each voxel is.
 - Just let it spawn chunks and override it via `set_voxel`. I'd like to avoid this as it wastes resources, especially for large worlds.
 
 # Proposal
Looking at Bevy, it seems like one of the best tools for determining when systems should run is the `run_if` conditional, that lets you pass a chain of `Conditions`, eg. `in_state(LoadingState::Ready)`. I have added a new configuration method `get_run_if_condition` that defaults to "run always", but that you could override via an `in_state(...` or some other creative condition.

I added a new example to illustrate this use case.
 
# Getting this PR Building
As I said above this doesn't build yet. I'm having trouble with generics around the `Condition` return type. The following builds, but my example does not:

Builds:

```
    fn get_run_if_condition(&self) -> impl Condition<()> {
        IntoSystem::into_system(|| true)
    }
```

Does not build:

```
    fn get_run_if_condition(&self) -> impl Condition<()> {
        in_state(LoadingState::Ready)
    }
```

If you have any time to try out the example, and see what I could define the `Condition<()>` return type as to make this work, it would be awesome. There's a less flexible version of this at https://github.com/splashdust/bevy_voxel_world/commit/49347209dacb86363f1a3e460b36ccad1ae44174. It's less flexible because it only lets you choose a single state.

But in general, let me know what you think of the proposal!