### PR TITLE
fix: nearby chunk churn

### DIFF
--- a/examples/bombs.rs
+++ b/examples/bombs.rs
@@ -9,7 +9,7 @@ impl VoxelWorldConfig for MainWorld {
     type MaterialIndex = u8;
     type ChunkUserBundle = ();
 
-    fn spawning_distance(&self) -> u32 {
+    fn max_spawning_distance(&self) -> u32 {
         15
     }
 

--- a/examples/custom_meshing.rs
+++ b/examples/custom_meshing.rs
@@ -37,7 +37,7 @@ impl VoxelWorldConfig for MainWorld {
     // function, you can define its type here. Otherwise, set it to `()`.
     type ChunkUserBundle = ();
 
-    fn spawning_distance(&self) -> u32 {
+    fn max_spawning_distance(&self) -> u32 {
         25
     }
 

--- a/examples/multiple_worlds.rs
+++ b/examples/multiple_worlds.rs
@@ -30,7 +30,7 @@ impl VoxelWorldConfig for MainWorld {
     type MaterialIndex = u8;
     type ChunkUserBundle = ();
 
-    fn spawning_distance(&self) -> u32 {
+    fn max_spawning_distance(&self) -> u32 {
         10
     }
 

--- a/examples/noise_terrain.rs
+++ b/examples/noise_terrain.rs
@@ -11,8 +11,12 @@ impl VoxelWorldConfig for MainWorld {
     type MaterialIndex = u8;
     type ChunkUserBundle = ();
 
-    fn spawning_distance(&self) -> u32 {
+    fn max_spawning_distance(&self) -> u32 {
         25
+    }
+
+    fn min_spawning_distance(&self) -> u32 {
+        1
     }
 
     fn voxel_lookup_delegate(&self) -> VoxelLookupDelegate<Self::MaterialIndex> {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -56,9 +56,14 @@ pub trait VoxelWorldConfig: Resource + Default + Clone {
     /// If you are not using this feature, you can set this to `()`.
     type ChunkUserBundle: Bundle + Clone;
 
-    /// Distance in chunks to spawn chunks around the camera
-    fn spawning_distance(&self) -> u32 {
+    /// Maximum distance in chunks to spawn chunks, whether in view or not, depending on the ChunkSpawnStrategy
+    fn max_spawning_distance(&self) -> u32 {
         10
+    }
+
+    /// Minimum distance in chunks to spawn chunks. This radius will always be spawned around the camera.
+    fn min_spawning_distance(&self) -> u32 {
+        1
     }
 
     /// Strategy for despawning chunks


### PR DESCRIPTION
Problem: Chunks near the camera will always be spawned in. However, with the FarAwayOrOutOfView despawn strategy, they will also be out of view and therefore culled. This means every frame they will continuously spawn and despawn.

Solution:
1. Check the distance around the camera when retiring chunks to ensure that, even if they are out of view, they should not be kept as they are near the camera
2. Make this distance around the camera configurable. A use case for this may be: wanting chunks near the player to be loaded, potentially for nearby dynamic physics objects or NPCs who depend upon terrain colliders that are driven from chunk generation from this plugin, but also wanting a long draw distance for chunks that are in view, beyond what would be feasible for loading chunks that are out of view

[Screencast from 2025-06-03 22-03-14.webm](https://github.com/user-attachments/assets/7c3608d6-e2b2-40db-a840-891e0d51c16a)
_(Compare video with video in issue, logs are the same)_

Fixes #65