### PR TITLE
Introduce per-chunk level-of-detail with configurable chunk shapes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
+  CARGO_PROFILE_DEV_DEBUG: 0
 
 jobs:
   # Run cargo test
@@ -34,6 +37,8 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: Run cargo test
         run: cargo test
+        env:
+          RUSTFLAGS: "-C debuginfo=0"
 
   # Run cargo clippy -- -D warnings
   clippy_check:
@@ -61,6 +66,8 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: Run clippy
         run: cargo clippy -- -D warnings
+        env:
+          RUSTFLAGS: "-C debuginfo=0"
 
   # Run cargo fmt --all -- --check
   format:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.14.0
+
+
 ## 0.13.0
 
 - Upgrade to Bevy 0.17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.14.0
 
+ - Introduce per-chunk level-of-detail and configurable chunk shapes
+ - Add `ChunkRegenerateStrategy`
+ - Add `max_active_chunk_threads()` and `attach_chunks_to_root()` knobs for better control over task-pool pressure and transform hierarchy costs.
 
 ## 0.13.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_voxel_world"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ahash 0.8.12",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,11 @@ name = "noise_terrain"
 path = "examples/noise_terrain.rs"
 
 [[example]]
+name = "noise_terrain_lod"
+path = "examples/noise_terrain_lod.rs"
+required-features = ["noise"]
+
+[[example]]
 name = "custom_meshing"
 path = "examples/custom_meshing.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ exclude = ["/assets/", "/examples/", "/.github/"]
 keywords = ["bevy", "voxels", "gamedev", "voxelengine"]
 categories = ["game-development", "graphics"]
 
+# Enable a small amount of optimization in the dev profile.
+[profile.dev]
+opt-level = 1
+
 [profile.dev.package."*"]
 opt-level = 3
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_voxel_world"
 description = "A voxel world plugin for Bevy"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 authors = ["Joacim Magnusson <joacim@isogram.se>"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -156,6 +156,15 @@ current LOD value together with the previously generated `ChunkData` (if any).
 This allows reuse of cached information when a chunk's LOD changes without
 forcing full regeneration from scratch.
 
+You can further control how voxel data is rebuilt by overriding
+`VoxelWorldConfig::chunk_regenerate_strategy`. The default behaviour reuses the
+previously generated `ChunkData` whenever possible, only invoking the voxel
+lookup delegate for positions that need new data. When you need to fully rebuild
+a chunk (for example when using a bespoke low-detail representation), return
+`ChunkRegenerateStrategy::Repopulate`. The voxel lookup closure now receives an
+`Option<WorldVoxel>` describing the previous value for each sample, making it
+easy to decide whether to reuse or replace on a per-voxel basis.
+
 ## Gotchas
 
 `bevy_voxel_world` began as an internal part of a game that I'm working on, but I figured that it could be useful as a standalone plugin, for myself and perhaps for others, so I decided to break it out and make it public as a crate.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ See this [full example of custom meshing](https://github.com/splashdust/bevy_vox
 
 ## Level of Detail
 
-Worlds can compute a per-chunk level-of-detail (LOD) value by overriding `VoxelWorldConfig::chunk_lod`. The default implementation always returns `0`, so nothing changes unless you opt in. When a chunk's LOD changes it is automatically marked for regeneration and remeshing to apply the new data.
+Worlds can compute a per-chunk level-of-detail (LOD) value by overriding `VoxelWorldConfig::chunk_lod`. The callback receives both the chunk position and the previously assigned LOD (if any). The default implementation always returns `0`, so nothing changes unless you opt in. When a chunk's LOD changes it is automatically marked for regeneration and remeshing to apply the new data.
 
 Once you provide your own LOD value, the following hooks become available:
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,19 @@ See this [full example of custom meshing](https://github.com/splashdust/bevy_vox
 
 <img width="558" src="https://github.com/user-attachments/assets/13f46fd6-81a8-4c93-943c-9c5fc7b9b38e"/>
 
+## Level of Detail
+
+Worlds can compute a level-of-detail (LOD) value per chunk by overriding
+`VoxelWorldConfig::chunk_lod`. The default implementation always returns `0`,
+so nothing changes unless you opt in. When a chunk's LOD changes, it is
+automatically marked for regeneration and remeshing so that the new data is
+applied.
+
+Both `voxel_lookup_delegate` and `chunk_meshing_delegate` now receive the
+current LOD value together with the previously generated `ChunkData` (if any).
+This allows reuse of cached information when a chunk's LOD changes without
+forcing full regeneration from scratch.
+
 ## Gotchas
 
 `bevy_voxel_world` began as an internal part of a game that I'm working on, but I figured that it could be useful as a standalone plugin, for myself and perhaps for others, so I decided to break it out and make it public as a crate.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ See this [full example of custom meshing](https://github.com/splashdust/bevy_vox
 
 ## Level of Detail
 
-Worlds can compute a per-chunk level-of-detail (LOD) value by overriding `VoxelWorldConfig::chunk_lod`. The callback receives both the chunk position and the previously assigned LOD (if any). The default implementation always returns `0`, so nothing changes unless you opt in. When a chunk's LOD changes it is automatically marked for regeneration and remeshing to apply the new data.
+Worlds can compute a per-chunk level-of-detail (LOD) value by overriding `VoxelWorldConfig::chunk_lod`. The callback receives both the chunk position and the previously assigned LOD (if any). The default implementation always returns `0`, so nothing changes unless you opt in. When a chunk's LOD changes it is automatically marked for regeneration and remeshing to apply the new data, and a `ChunkWillChangeLod` event is fired so gameplay/UI systems can react even if no remesh is needed.
 
 Once you provide your own LOD value, the following hooks become available:
 

--- a/examples/bombs.rs
+++ b/examples/bombs.rs
@@ -17,7 +17,7 @@ impl VoxelWorldConfig for MainWorld {
     }
 
     fn voxel_lookup_delegate(&self) -> VoxelLookupDelegate<Self::MaterialIndex> {
-        Box::new(move |_chunk_pos| get_voxel_fn())
+        Box::new(move |_chunk_pos, _lod, _previous| get_voxel_fn())
     }
 
     fn texture_index_mapper(

--- a/examples/bombs.rs
+++ b/examples/bombs.rs
@@ -84,7 +84,8 @@ fn setup(mut commands: Commands) {
     });
 }
 
-fn get_voxel_fn() -> Box<dyn FnMut(IVec3) -> WorldVoxel + Send + Sync> {
+fn get_voxel_fn(
+) -> Box<dyn FnMut(IVec3, Option<WorldVoxel>) -> WorldVoxel + Send + Sync> {
     // Set up some noise to use as the terrain height map
     let mut noise = HybridMulti::<Perlin>::new(1234);
     noise.octaves = 4;
@@ -98,7 +99,7 @@ fn get_voxel_fn() -> Box<dyn FnMut(IVec3) -> WorldVoxel + Send + Sync> {
 
     // Then we return this boxed closure that captures the noise and the cache
     // This will get sent off to a separate thread for meshing by bevy_voxel_world
-    Box::new(move |pos: IVec3| {
+    Box::new(move |pos: IVec3, _previous| {
         // Sea level
         if pos.y < 1 {
             return WorldVoxel::Solid(3);

--- a/examples/bombs.rs
+++ b/examples/bombs.rs
@@ -84,8 +84,8 @@ fn setup(mut commands: Commands) {
     });
 }
 
-fn get_voxel_fn(
-) -> Box<dyn FnMut(IVec3, Option<WorldVoxel>) -> WorldVoxel + Send + Sync> {
+fn get_voxel_fn() -> Box<dyn FnMut(IVec3, Option<WorldVoxel>) -> WorldVoxel + Send + Sync>
+{
     // Set up some noise to use as the terrain height map
     let mut noise = HybridMulti::<Perlin>::new(1234);
     noise.octaves = 4;

--- a/examples/custom_meshing.rs
+++ b/examples/custom_meshing.rs
@@ -81,7 +81,7 @@ impl VoxelWorldConfig for MainWorld {
 
                     // Call the greedy meshing algorithm from the block_mesh crate
                     block_mesh::greedy_quads(
-                        &*voxels,
+                        &voxels,
                         &PaddedChunkShape {},
                         [0; 3],
                         [CHUNK_SIZE_U + 1; 3],

--- a/examples/custom_meshing.rs
+++ b/examples/custom_meshing.rs
@@ -213,7 +213,8 @@ fn setup(mut commands: Commands) {
     });
 }
 
-fn get_voxel_fn() -> Box<dyn FnMut(IVec3) -> WorldVoxel + Send + Sync> {
+fn get_voxel_fn(
+) -> Box<dyn FnMut(IVec3, Option<WorldVoxel>) -> WorldVoxel + Send + Sync> {
     // Set up some noise to use as the terrain height map
     let mut noise = HybridMulti::<Perlin>::new(1234);
     noise.octaves = 5;
@@ -227,7 +228,7 @@ fn get_voxel_fn() -> Box<dyn FnMut(IVec3) -> WorldVoxel + Send + Sync> {
 
     // Then we return this boxed closure that captures the noise and the cache
     // This will get sent off to a separate thread for meshing by bevy_voxel_world
-    Box::new(move |pos: IVec3| {
+    Box::new(move |pos: IVec3, _previous| {
         // Sea level
         if pos.y < 1 {
             return WorldVoxel::Solid(3);

--- a/examples/custom_meshing.rs
+++ b/examples/custom_meshing.rs
@@ -213,8 +213,8 @@ fn setup(mut commands: Commands) {
     });
 }
 
-fn get_voxel_fn(
-) -> Box<dyn FnMut(IVec3, Option<WorldVoxel>) -> WorldVoxel + Send + Sync> {
+fn get_voxel_fn() -> Box<dyn FnMut(IVec3, Option<WorldVoxel>) -> WorldVoxel + Send + Sync>
+{
     // Set up some noise to use as the terrain height map
     let mut noise = HybridMulti::<Perlin>::new(1234);
     noise.octaves = 5;

--- a/examples/custom_meshing.rs
+++ b/examples/custom_meshing.rs
@@ -40,7 +40,7 @@ impl VoxelWorldConfig for MainWorld {
     }
 
     fn voxel_lookup_delegate(&self) -> VoxelLookupDelegate<Self::MaterialIndex> {
-        Box::new(move |_chunk_pos| get_voxel_fn())
+        Box::new(move |_chunk_pos, _lod, _previous| get_voxel_fn())
     }
 
     fn texture_index_mapper(
@@ -65,7 +65,7 @@ impl VoxelWorldConfig for MainWorld {
     fn chunk_meshing_delegate(
         &self,
     ) -> ChunkMeshingDelegate<Self::MaterialIndex, Self::ChunkUserBundle> {
-        Some(Box::new(|_pos: IVec3| {
+        Some(Box::new(|_pos: IVec3, _lod, _previous| {
             // If necessary, we can caputure data here based on the chunk position
             // and move it into the closure below.
             Box::new(

--- a/examples/custom_meshing.rs
+++ b/examples/custom_meshing.rs
@@ -65,12 +65,15 @@ impl VoxelWorldConfig for MainWorld {
     fn chunk_meshing_delegate(
         &self,
     ) -> ChunkMeshingDelegate<Self::MaterialIndex, Self::ChunkUserBundle> {
-        Some(Box::new(|_pos: IVec3, _lod, _previous| {
-            // If necessary, we can caputure data here based on the chunk position
-            // and move it into the closure below.
-            Box::new(
+        Some(Box::new(
+            |_pos: IVec3, _lod, _data_shape, _mesh_shape, _previous| {
+                // If necessary, we can caputure data here based on the chunk position
+                // and move it into the closure below.
+                Box::new(
                 // The array of voxels for the chunk
                 |voxels: VoxelArray<Self::MaterialIndex>,
+                 _data_shape_in: UVec3,
+                 _mesh_shape_in: UVec3,
                  // A reference to the texture index mapper function as defined in the config
                  texture_index_mapper: TextureIndexMapperFn<Self::MaterialIndex>| {
                     let faces = block_mesh::RIGHT_HANDED_Y_UP_CONFIG.faces;
@@ -157,7 +160,8 @@ impl VoxelWorldConfig for MainWorld {
                     (render_mesh, None)
                 },
             )
-        }))
+            },
+        ))
     }
 }
 

--- a/examples/multiple_noise_terrain.rs
+++ b/examples/multiple_noise_terrain.rs
@@ -89,8 +89,7 @@ fn setup(mut commands: Commands) {
     });
 }
 
-fn get_voxel_fn(
-) -> Box<
+fn get_voxel_fn() -> Box<
     dyn FnMut(IVec3, Option<WorldVoxel<BlockTexture>>) -> WorldVoxel<BlockTexture>
         + Send
         + Sync,

--- a/examples/multiple_noise_terrain.rs
+++ b/examples/multiple_noise_terrain.rs
@@ -32,7 +32,7 @@ impl VoxelWorldConfig for MainWorld {
     }
 
     fn voxel_lookup_delegate(&self) -> VoxelLookupDelegate<Self::MaterialIndex> {
-        Box::new(move |_chunk_pos| get_voxel_fn())
+        Box::new(move |_chunk_pos, _lod, _previous| get_voxel_fn())
     }
 
     fn texture_index_mapper(

--- a/examples/multiple_noise_terrain.rs
+++ b/examples/multiple_noise_terrain.rs
@@ -89,7 +89,12 @@ fn setup(mut commands: Commands) {
     });
 }
 
-fn get_voxel_fn() -> Box<dyn FnMut(IVec3) -> WorldVoxel<BlockTexture> + Send + Sync> {
+fn get_voxel_fn(
+) -> Box<
+    dyn FnMut(IVec3, Option<WorldVoxel<BlockTexture>>) -> WorldVoxel<BlockTexture>
+        + Send
+        + Sync,
+> {
     // Set up some noise to use as the terrain height map
     let mut noise = HybridMulti::<Perlin>::new(1234);
     noise.octaves = 5;
@@ -110,7 +115,7 @@ fn get_voxel_fn() -> Box<dyn FnMut(IVec3) -> WorldVoxel<BlockTexture> + Send + S
 
     // Then we return this boxed closure that captures the noise and the cache
     // This will get sent off to a separate thread for meshing by bevy_voxel_world
-    Box::new(move |pos: IVec3| {
+    Box::new(move |pos: IVec3, _previous| {
         // Sea level
         if pos.y < 1 {
             return WorldVoxel::Solid(BlockTexture::Snow);

--- a/examples/multiple_worlds.rs
+++ b/examples/multiple_worlds.rs
@@ -126,7 +126,8 @@ fn setup(mut commands: Commands, mut second_world: VoxelWorld<SecondWorld>) {
     second_world.set_voxel(IVec3::new(0, 3, 0), WorldVoxel::Solid(RED));
 }
 
-fn get_voxel_fn() -> Box<dyn FnMut(IVec3) -> WorldVoxel + Send + Sync> {
+fn get_voxel_fn(
+) -> Box<dyn FnMut(IVec3, Option<WorldVoxel>) -> WorldVoxel + Send + Sync> {
     // Set up some noise to use as the terrain height map
     let mut noise = HybridMulti::<Perlin>::new(1234);
     noise.octaves = 4;
@@ -140,7 +141,7 @@ fn get_voxel_fn() -> Box<dyn FnMut(IVec3) -> WorldVoxel + Send + Sync> {
 
     // Then we return this boxed closure that captures the noise and the cache
     // This will get sent off to a separate thread for meshing by bevy_voxel_world
-    Box::new(move |pos: IVec3| {
+    Box::new(move |pos: IVec3, _previous| {
         // Sea level
         if pos.y < 1 {
             return WorldVoxel::Solid(3);

--- a/examples/multiple_worlds.rs
+++ b/examples/multiple_worlds.rs
@@ -126,8 +126,8 @@ fn setup(mut commands: Commands, mut second_world: VoxelWorld<SecondWorld>) {
     second_world.set_voxel(IVec3::new(0, 3, 0), WorldVoxel::Solid(RED));
 }
 
-fn get_voxel_fn(
-) -> Box<dyn FnMut(IVec3, Option<WorldVoxel>) -> WorldVoxel + Send + Sync> {
+fn get_voxel_fn() -> Box<dyn FnMut(IVec3, Option<WorldVoxel>) -> WorldVoxel + Send + Sync>
+{
     // Set up some noise to use as the terrain height map
     let mut noise = HybridMulti::<Perlin>::new(1234);
     noise.octaves = 4;

--- a/examples/multiple_worlds.rs
+++ b/examples/multiple_worlds.rs
@@ -34,7 +34,7 @@ impl VoxelWorldConfig for MainWorld {
     }
 
     fn voxel_lookup_delegate(&self) -> VoxelLookupDelegate<Self::MaterialIndex> {
-        Box::new(move |_chunk_pos| get_voxel_fn())
+        Box::new(move |_chunk_pos, _lod, _previous| get_voxel_fn())
     }
 
     fn texture_index_mapper(

--- a/examples/navigation.rs
+++ b/examples/navigation.rs
@@ -59,42 +59,53 @@ impl VoxelWorldConfig for MyMainWorld {
     fn chunk_meshing_delegate(
         &self,
     ) -> ChunkMeshingDelegate<Self::MaterialIndex, Self::ChunkUserBundle> {
-        Some(Box::new(|pos: IVec3, _lod, _previous| {
-            Box::new(move |voxels, texture_index_mapper| {
-                // Use the crate's default meshing to build the mesh.
-                let mesh = generate_chunk_mesh(voxels.clone(), pos, texture_index_mapper);
+        Some(Box::new(
+            |pos: IVec3, _lod, _data_shape, _mesh_shape, _previous| {
+                Box::new(
+                    move |voxels,
+                          _data_shape_in,
+                          _mesh_shape_in,
+                          texture_index_mapper| {
+                        // Use the crate's default meshing to build the mesh.
+                        let mesh = generate_chunk_mesh(
+                            voxels.clone(),
+                            pos,
+                            texture_index_mapper,
+                        );
 
-                // Build per-chunk navigation: cells are passable when Air above Solid.
-                let mut passable = Vec::new();
-                let base = (pos * CHUNK_SIZE_U as i32).as_uvec3();
-                for x in 0..CHUNK_SIZE_U {
-                    for z in 0..CHUNK_SIZE_U {
-                        for y in 0..CHUNK_SIZE_U {
-                            let above_local = UVec3::new(x + 1, y + 1, z + 1);
-                            let below_local = UVec3::new(x + 1, y, z + 1);
-                            let vox_above = voxels[PaddedChunkShape::linearize(
-                                above_local.to_array(),
-                            )
-                                as usize];
-                            let vox_below = voxels[PaddedChunkShape::linearize(
-                                below_local.to_array(),
-                            )
-                                as usize];
-                            if vox_above.is_air() && vox_below.is_solid() {
-                                passable.push(base + UVec3::new(x, y, z));
+                        // Build per-chunk navigation: cells are passable when Air above Solid.
+                        let mut passable = Vec::new();
+                        let base = (pos * CHUNK_SIZE_U as i32).as_uvec3();
+                        for x in 0..CHUNK_SIZE_U {
+                            for z in 0..CHUNK_SIZE_U {
+                                for y in 0..CHUNK_SIZE_U {
+                                    let above_local = UVec3::new(x + 1, y + 1, z + 1);
+                                    let below_local = UVec3::new(x + 1, y, z + 1);
+                                    let vox_above = voxels[PaddedChunkShape::linearize(
+                                        above_local.to_array(),
+                                    )
+                                        as usize];
+                                    let vox_below = voxels[PaddedChunkShape::linearize(
+                                        below_local.to_array(),
+                                    )
+                                        as usize];
+                                    if vox_above.is_air() && vox_below.is_solid() {
+                                        passable.push(base + UVec3::new(x, y, z));
+                                    }
+                                }
                             }
                         }
-                    }
-                }
 
-                (
-                    mesh,
-                    Some(ChunkNavBundle {
-                        nav: ChunkNav { passable },
-                    }),
+                        (
+                            mesh,
+                            Some(ChunkNavBundle {
+                                nav: ChunkNav { passable },
+                            }),
+                        )
+                    },
                 )
-            })
-        }))
+            },
+        ))
     }
 }
 

--- a/examples/navigation.rs
+++ b/examples/navigation.rs
@@ -53,13 +53,13 @@ impl VoxelWorldConfig for MyMainWorld {
     }
 
     fn voxel_lookup_delegate(&self) -> VoxelLookupDelegate<Self::MaterialIndex> {
-        Box::new(move |_chunk_pos| create_voxel_floor())
+        Box::new(move |_chunk_pos, _lod, _previous| create_voxel_floor())
     }
 
     fn chunk_meshing_delegate(
         &self,
     ) -> ChunkMeshingDelegate<Self::MaterialIndex, Self::ChunkUserBundle> {
-        Some(Box::new(|pos: IVec3| {
+        Some(Box::new(|pos: IVec3, _lod, _previous| {
             Box::new(move |voxels, texture_index_mapper| {
                 // Use the crate's default meshing to build the mesh.
                 let mesh = generate_chunk_mesh(voxels.clone(), pos, texture_index_mapper);

--- a/examples/navigation.rs
+++ b/examples/navigation.rs
@@ -245,8 +245,9 @@ fn create_voxel_scene(mut voxel_world: VoxelWorld<MyMainWorld>) {
     voxel_world.set_voxel(IVec3::new(16, 2, 16), WorldVoxel::Solid(SNOWY_BRICK));
 }
 
-fn create_voxel_floor() -> Box<dyn FnMut(IVec3) -> WorldVoxel + Send + Sync> {
-    Box::new(move |pos: IVec3| {
+fn create_voxel_floor(
+) -> Box<dyn FnMut(IVec3, Option<WorldVoxel>) -> WorldVoxel + Send + Sync> {
+    Box::new(move |pos: IVec3, _previous| {
         if pos.x > 0
             && pos.z > 0
             && pos.x < FLOOR_SIZE as i32

--- a/examples/noise_terrain.rs
+++ b/examples/noise_terrain.rs
@@ -77,8 +77,8 @@ fn setup(mut commands: Commands) {
     });
 }
 
-fn get_voxel_fn(
-) -> Box<dyn FnMut(IVec3, Option<WorldVoxel>) -> WorldVoxel + Send + Sync> {
+fn get_voxel_fn() -> Box<dyn FnMut(IVec3, Option<WorldVoxel>) -> WorldVoxel + Send + Sync>
+{
     // Set up some noise to use as the terrain height map
     let mut noise = HybridMulti::<Perlin>::new(1234);
     noise.octaves = 5;

--- a/examples/noise_terrain.rs
+++ b/examples/noise_terrain.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use bevy::{
     light::CascadeShadowConfigBuilder, platform::collections::HashMap, prelude::*,
 };
-use bevy_voxel_world::prelude::*;
+use bevy_voxel_world::{custom_meshing::CHUNK_SIZE_F, prelude::*};
 use noise::{HybridMulti, NoiseFn, Perlin};
 
 #[derive(Resource, Clone, Default)]
@@ -14,7 +14,7 @@ impl VoxelWorldConfig for MainWorld {
     type ChunkUserBundle = ();
 
     fn spawning_distance(&self) -> u32 {
-        25
+        35
     }
 
     fn min_despawn_distance(&self) -> u32 {
@@ -22,7 +22,44 @@ impl VoxelWorldConfig for MainWorld {
     }
 
     fn voxel_lookup_delegate(&self) -> VoxelLookupDelegate<Self::MaterialIndex> {
-        Box::new(move |_chunk_pos, _lod, _previous| get_voxel_fn())
+        Box::new(move |_chunk_pos, _lod, _previous| {
+            // Set up some noise to use as the terrain height map
+            let mut noise = HybridMulti::<Perlin>::new(1234);
+            noise.octaves = 5;
+            noise.frequency = 1.1;
+            noise.lacunarity = 2.8;
+            noise.persistence = 0.4;
+
+            // Cache the noise value for each y column so we only calculate it once
+            let mut cache = HashMap::<(i32, i32), f64>::new();
+
+            // This closure gets sent to a separate thread for meshing by bevy_voxel_world
+            Box::new(move |pos: IVec3| {
+                // Sea level
+                if pos.y < 1 {
+                    return WorldVoxel::Solid(3);
+                }
+
+                let [x, y, z] = pos.as_dvec3().to_array();
+
+                // Sample terrain column once, then reuse from the cache
+                let is_ground = y < match cache.get(&(pos.x, pos.z)) {
+                    Some(sample) => *sample,
+                    None => {
+                        let sample = noise.get([x / 1000.0, z / 1000.0]) * 50.0;
+                        cache.insert((pos.x, pos.z), sample);
+                        sample
+                    }
+                };
+
+                if is_ground {
+                    // Solid voxel of material type 0
+                    WorldVoxel::Solid(0)
+                } else {
+                    WorldVoxel::Air
+                }
+            })
+        })
     }
 
     fn texture_index_mapper(
@@ -35,6 +72,21 @@ impl VoxelWorldConfig for MainWorld {
             3 => [3, 3, 3],
             _ => [0, 0, 0],
         })
+    }
+
+    fn chunk_lod(&self, chunk_position: IVec3, camera_position: Vec3) -> LodLevel {
+        let camera_chunk = (camera_position / CHUNK_SIZE_F).floor();
+        let distance = chunk_position.as_vec3().distance(camera_chunk);
+
+        if distance < 5.0 {
+            0
+        } else if distance < 10.0 {
+            1
+        } else if distance < 20.0 {
+            2
+        } else {
+            3
+        }
     }
 }
 
@@ -75,47 +127,6 @@ fn setup(mut commands: Commands) {
         brightness: 100.0,
         affects_lightmapped_meshes: true,
     });
-}
-
-fn get_voxel_fn() -> Box<dyn FnMut(IVec3) -> WorldVoxel + Send + Sync> {
-    // Set up some noise to use as the terrain height map
-    let mut noise = HybridMulti::<Perlin>::new(1234);
-    noise.octaves = 5;
-    noise.frequency = 1.1;
-    noise.lacunarity = 2.8;
-    noise.persistence = 0.4;
-
-    // We use this to cache the noise value for each y column so we only need
-    // to calculate it once per x/z coordinate
-    let mut cache = HashMap::<(i32, i32), f64>::new();
-
-    // Then we return this boxed closure that captures the noise and the cache
-    // This will get sent off to a separate thread for meshing by bevy_voxel_world
-    Box::new(move |pos: IVec3| {
-        // Sea level
-        if pos.y < 1 {
-            return WorldVoxel::Solid(3);
-        }
-
-        let [x, y, z] = pos.as_dvec3().to_array();
-
-        // If y is less than the noise sample, we will set the voxel to solid
-        let is_ground = y < match cache.get(&(pos.x, pos.z)) {
-            Some(sample) => *sample,
-            None => {
-                let sample = noise.get([x / 1000.0, z / 1000.0]) * 50.0;
-                cache.insert((pos.x, pos.z), sample);
-                sample
-            }
-        };
-
-        if is_ground {
-            // Solid voxel of material type 0
-            WorldVoxel::Solid(0)
-        } else {
-            WorldVoxel::Air
-        }
-    })
 }
 
 fn move_camera(

--- a/examples/noise_terrain.rs
+++ b/examples/noise_terrain.rs
@@ -22,7 +22,7 @@ impl VoxelWorldConfig for MainWorld {
     }
 
     fn voxel_lookup_delegate(&self) -> VoxelLookupDelegate<Self::MaterialIndex> {
-        Box::new(move |_chunk_pos| get_voxel_fn())
+        Box::new(move |_chunk_pos, _lod, _previous| get_voxel_fn())
     }
 
     fn texture_index_mapper(

--- a/examples/noise_terrain.rs
+++ b/examples/noise_terrain.rs
@@ -77,7 +77,8 @@ fn setup(mut commands: Commands) {
     });
 }
 
-fn get_voxel_fn() -> Box<dyn FnMut(IVec3) -> WorldVoxel + Send + Sync> {
+fn get_voxel_fn(
+) -> Box<dyn FnMut(IVec3, Option<WorldVoxel>) -> WorldVoxel + Send + Sync> {
     // Set up some noise to use as the terrain height map
     let mut noise = HybridMulti::<Perlin>::new(1234);
     noise.octaves = 5;
@@ -91,7 +92,7 @@ fn get_voxel_fn() -> Box<dyn FnMut(IVec3) -> WorldVoxel + Send + Sync> {
 
     // Then we return this boxed closure that captures the noise and the cache
     // This will get sent off to a separate thread for meshing by bevy_voxel_world
-    Box::new(move |pos: IVec3| {
+    Box::new(move |pos: IVec3, _previous| {
         // Sea level
         if pos.y < 1 {
             return WorldVoxel::Solid(3);

--- a/examples/noise_terrain_lod.rs
+++ b/examples/noise_terrain_lod.rs
@@ -1,0 +1,159 @@
+use std::sync::Arc;
+
+use bevy::{
+    light::CascadeShadowConfigBuilder, platform::collections::HashMap, prelude::*,
+};
+use bevy_voxel_world::{
+    custom_meshing::CHUNK_SIZE_F,
+    prelude::*,
+};
+use noise::{HybridMulti, NoiseFn, Perlin};
+
+#[derive(Resource, Clone)]
+struct MainWorld {
+    noise: Arc<HybridMulti<Perlin>>,
+}
+
+impl Default for MainWorld {
+    fn default() -> Self {
+        let mut noise = HybridMulti::<Perlin>::new(1234);
+        noise.octaves = 5;
+        noise.frequency = 1.1;
+        noise.lacunarity = 2.8;
+        noise.persistence = 0.4;
+
+        Self {
+            noise: Arc::new(noise),
+        }
+    }
+}
+
+impl VoxelWorldConfig for MainWorld {
+    type MaterialIndex = u8;
+    type ChunkUserBundle = ();
+
+    fn spawning_distance(&self) -> u32 {
+        50
+    }
+
+    fn min_despawn_distance(&self) -> u32 {
+        1
+    }
+
+    fn voxel_lookup_delegate(&self) -> VoxelLookupDelegate<Self::MaterialIndex> {
+        let chunk_noise = Arc::clone(&self.noise);
+        Box::new(move |chunk_pos, lod, previous| {
+            if chunk_pos.y < 1 {
+                return Box::new(|_| WorldVoxel::Solid(3));
+            }
+            if chunk_pos.y > 4 {
+                return Box::new(|_| WorldVoxel::Air);
+            }
+
+            let noise = Arc::clone(&chunk_noise);
+
+            // We use this to cache the noise value for each y column so we only need
+            // to calculate it once per x/z coordinate
+            let mut cache = HashMap::<(i32, i32), f64>::new();
+
+            // Then we return this boxed closure that captures the noise and the cache
+            // This will get sent off to a separate thread for meshing by bevy_voxel_world
+            Box::new(move |pos: IVec3| {
+                let [x, y, z] = pos.as_dvec3().to_array();
+
+                // If y is less than the noise sample, we will set the voxel to solid
+                let is_ground = y < match cache.get(&(pos.x, pos.z)) {
+                    Some(sample) => *sample,
+                    None => {
+                        let sample = noise.get([x / 1000.0, z / 1000.0]) * 50.0;
+                        cache.insert((pos.x, pos.z), sample);
+                        sample
+                    }
+                };
+
+                if is_ground {
+                    // Solid voxel of material type 0
+                    WorldVoxel::Solid(0)
+                } else {
+                    WorldVoxel::Air
+                }
+            })
+        })
+    }
+
+    fn texture_index_mapper(
+        &self,
+    ) -> Arc<dyn Fn(Self::MaterialIndex) -> [u32; 3] + Send + Sync> {
+        Arc::new(|mat| match mat {
+            0 => [0, 0, 0],
+            1 => [1, 1, 1],
+            2 => [2, 2, 2],
+            3 => [3, 3, 3],
+            _ => [0, 0, 0],
+        })
+    }
+
+    fn chunk_lod(&self, chunk_position: IVec3, camera_position: Vec3) -> LodLevel {
+        let camera_chunk = (camera_position / CHUNK_SIZE_F).floor();
+        let distance = chunk_position.as_vec3().distance(camera_chunk);
+
+        if distance < 5.0 {
+            1
+        } else if distance < 10.0 {
+            2
+        } else if distance < 20.0 {
+            4
+        } else {
+            8
+        }
+    }
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(VoxelWorldPlugin::with_config(MainWorld::default()))
+        .add_systems(Startup, setup)
+        .add_systems(Update, move_camera)
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    // camera
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-200.0, 180.0, -200.0).looking_at(Vec3::ZERO, Vec3::Y),
+        // This tells bevy_voxel_world to use this cameras transform to calculate spawning area
+        VoxelWorldCamera::<MainWorld>::default(),
+    ));
+
+    // Sun
+    let cascade_shadow_config = CascadeShadowConfigBuilder { ..default() }.build();
+    commands.spawn((
+        DirectionalLight {
+            color: Color::srgb(0.98, 0.95, 0.82),
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::from_xyz(0.0, 0.0, 0.0)
+            .looking_at(Vec3::new(-0.15, -0.1, 0.15), Vec3::Y),
+        cascade_shadow_config,
+    ));
+
+    // Ambient light, same color as sun
+    commands.insert_resource(AmbientLight {
+        color: Color::srgb(0.98, 0.95, 0.82),
+        brightness: 100.0,
+        affects_lightmapped_meshes: true,
+    });
+}
+
+fn move_camera(
+    time: Res<Time>,
+    mut cam_transform: Query<&mut Transform, With<VoxelWorldCamera<MainWorld>>>,
+) {
+    if let Ok(mut transform) = cam_transform.single_mut() {
+        transform.translation.x += time.delta_secs() * 12.0;
+        transform.translation.z += time.delta_secs() * 24.0;
+    }
+}

--- a/examples/noise_terrain_lod.rs
+++ b/examples/noise_terrain_lod.rs
@@ -121,7 +121,12 @@ impl VoxelWorldConfig for MainWorld {
         padded_chunk_shape_uniform(CHUNK_SIZE_U / lod_level.max(1) as u32)
     }
 
-    fn chunk_lod(&self, chunk_position: IVec3, camera_position: Vec3) -> LodLevel {
+    fn chunk_lod(
+        &self,
+        chunk_position: IVec3,
+        _previous_lod: Option<LodLevel>,
+        camera_position: Vec3,
+    ) -> LodLevel {
         let camera_chunk = (camera_position / CHUNK_SIZE_F).floor();
         let distance = chunk_position.as_vec3().distance(camera_chunk);
 

--- a/examples/noise_terrain_lod.rs
+++ b/examples/noise_terrain_lod.rs
@@ -101,11 +101,11 @@ impl VoxelWorldConfig for MainWorld {
     }
 
     fn chunk_data_shape(&self, lod_level: LodLevel) -> UVec3 {
-        padded_chunk_shape_uniform(CHUNK_SIZE_U / lod_level as u32)
+        padded_chunk_shape_uniform(CHUNK_SIZE_U / lod_level.max(1) as u32)
     }
 
     fn chunk_meshing_shape(&self, lod_level: LodLevel) -> UVec3 {
-        padded_chunk_shape_uniform(CHUNK_SIZE_U / lod_level as u32)
+        padded_chunk_shape_uniform(CHUNK_SIZE_U / lod_level.max(1) as u32)
     }
 
     fn chunk_lod(&self, chunk_position: IVec3, camera_position: Vec3) -> LodLevel {

--- a/examples/noise_terrain_lod.rs
+++ b/examples/noise_terrain_lod.rs
@@ -41,7 +41,7 @@ impl VoxelWorldConfig for MainWorld {
     fn voxel_lookup_delegate(&self) -> VoxelLookupDelegate<Self::MaterialIndex> {
         let chunk_noise = Arc::clone(&self.noise);
         Box::new(move |chunk_pos, lod, previous| {
-            if chunk_pos.y < 1 {
+            if chunk_pos.y < 0 {
                 return Box::new(|_, _| WorldVoxel::Solid(3));
             }
             if chunk_pos.y > 4 {
@@ -58,6 +58,11 @@ impl VoxelWorldConfig for MainWorld {
             // Then we return this boxed closure that captures the noise and the cache
             // This will get sent off to a separate thread for meshing by bevy_voxel_world
             Box::new(move |pos: IVec3, previous_voxel| {
+                // Sea level
+                if pos.y < 1 {
+                    return WorldVoxel::Solid(3);
+                }
+
                 let lod_step = i32::from(lod.max(1));
                 let base_x = pos.x.div_euclid(lod_step) * lod_step;
                 let base_z = pos.z.div_euclid(lod_step) * lod_step;

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -115,6 +115,38 @@ impl<I: Hash + Copy + PartialEq> ChunkData<I> {
         }
     }
 
+    /// Returns the voxel at the given world-space position if this chunk contains it.
+    pub fn get_voxel_at_world_position(
+        &self,
+        world_position: IVec3,
+    ) -> Option<WorldVoxel<I>> {
+        let chunk_pos = IVec3 {
+            x: (world_position.x as f32 / CHUNK_SIZE_F).floor() as i32,
+            y: (world_position.y as f32 / CHUNK_SIZE_F).floor() as i32,
+            z: (world_position.z as f32 / CHUNK_SIZE_F).floor() as i32,
+        };
+
+        if chunk_pos != self.position {
+            return None;
+        }
+
+        let offset = world_position - chunk_pos * CHUNK_SIZE_I;
+
+        if offset.cmplt(IVec3::ZERO).any()
+            || offset.cmpge(IVec3::splat(CHUNK_SIZE_I)).any()
+        {
+            return None;
+        }
+
+        let local = UVec3::new(
+            (offset.x as u32) + 1,
+            (offset.y as u32) + 1,
+            (offset.z as u32) + 1,
+        );
+
+        Some(self.get_voxel(local))
+    }
+
     /// Returns true if the chunk is full. No mesh will be generated for full chunks.
     pub fn is_full(&self) -> bool {
         self.is_full

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -125,6 +125,26 @@ impl<I: Hash + Copy + PartialEq> ChunkData<I> {
         self.is_empty
     }
 
+    /// Returns the chunk-space position of this chunk.
+    pub fn chunk_position(&self) -> IVec3 {
+        self.position
+    }
+
+    /// Returns the LOD level this chunk was generated with.
+    pub fn lod_level(&self) -> LodLevel {
+        self.lod_level
+    }
+
+    /// Returns the hash of the voxel payload, if any.
+    pub fn voxels_hash(&self) -> u64 {
+        self.voxels_hash
+    }
+
+    /// Returns a clone of the voxel array, if the chunk stores explicit voxels.
+    pub fn voxels_arc(&self) -> Option<Arc<VoxelArray<I>>> {
+        self.voxels.as_ref().map(Arc::clone)
+    }
+
     /// Returns the fill type of the chunk.
     /// This is used to determine the type of content in the chunk.
     ///

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -287,13 +287,13 @@ impl<I: Hash + Copy + PartialEq> ChunkData<I> {
     }
 
     /// Returns true if the given voxel is within the bounds of the chunk
-    /// and the voxel data at the given position matcheso the given voxel
+    /// and the voxel data at the given position matches the given voxel
     pub fn has_voxel(&self, voxel_pos: IVec3, voxel: WorldVoxel<I>) -> bool {
         let chunk_pos = voxel_pos / CHUNK_SIZE_I;
         if self.position != chunk_pos {
             return false;
         }
-        self.get_voxel(voxel_pos.as_uvec3() % CHUNK_SIZE_U) == voxel
+        self.get_voxel_at_world_position(voxel_pos) == Some(voxel)
     }
 
     /// Returns true if this chunk has been processed by the voxel generation system (typically to generate terrain)

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -453,8 +453,9 @@ impl<C: VoxelWorldConfig + Send + Sync + 'static, I: Hash + Copy + Eq> ChunkTask
                 continue;
             }
 
-            let previous_voxel = previous_data.as_ref().and_then(|chunk| {
-                chunk.get_voxel_at_world_position(block_pos)});
+            let previous_voxel = previous_data
+                .as_ref()
+                .and_then(|chunk| chunk.get_voxel_at_world_position(block_pos));
 
             if reuse_previous {
                 if let Some(prev_voxel) = previous_voxel {

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -441,6 +441,7 @@ impl<C: VoxelWorldConfig + Send + Sync + 'static, I: Hash + Copy + Eq> ChunkTask
         let mut active_shape = desired_shape;
 
         if reuse_previous
+            // Preserve the previously generated payload so the full-resolution voxels remain available when the chunk is promoted again.
             && previous_data
                 .as_ref()
                 .map(|chunk| chunk.has_generated())

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -43,28 +43,6 @@ fn voxel_size_from_shape(shape: &RuntimeShape<u32, 3>) -> Vec3 {
     )
 }
 
-fn map_nearest(position: UVec3, data_shape: UVec3) -> UVec3 {
-    let to_index = |pos_i: u32, data_dim: u32| -> u32 {
-        // scale the inner dimension of the padded shape
-        let scale = CHUNK_SIZE_F / (data_dim - 3) as f32;
-        let mut s = (((pos_i as f32 - 1.0) * scale).round() + 1.0) as i32;
-        if s < 0 {
-            s = 0;
-        }
-        let max = (data_dim as i32 - 1).max(0);
-        if s > max {
-            s = max;
-        }
-        s as u32
-    };
-
-    UVec3::new(
-        to_index(position.x, data_shape.x),
-        to_index(position.y, data_shape.y),
-        to_index(position.z, data_shape.z),
-    )
-}
-
 #[derive(Component)]
 #[component(storage = "SparseSet")]
 pub(crate) struct ChunkThread<C: VoxelWorldConfig, I>(

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -328,8 +328,7 @@ impl<C: VoxelWorldConfig + Send + Sync + 'static, I: Hash + Copy + Eq> ChunkTask
         mut voxel_data_fn: F,
         previous_data: Option<ChunkData<I>>,
         strategy: ChunkRegenerateStrategy,
-    )
-    where
+    ) where
         F: FnMut(IVec3, Option<WorldVoxel<I>>) -> WorldVoxel<I> + Send + 'static,
     {
         let mut filled_count = 0;

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -454,13 +454,7 @@ impl<C: VoxelWorldConfig + Send + Sync + 'static, I: Hash + Copy + Eq> ChunkTask
             }
 
             let previous_voxel = previous_data.as_ref().and_then(|chunk| {
-                chunk.get_voxel_at_world_position(block_pos).or_else(|| {
-                    match chunk.get_fill_type() {
-                        FillType::Uniform(voxel) => Some(*voxel),
-                        _ => Some(WorldVoxel::Unset),
-                    }
-                })
-            });
+                chunk.get_voxel_at_world_position(block_pos)});
 
             if reuse_previous {
                 if let Some(prev_voxel) = previous_voxel {

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -43,7 +43,6 @@ fn voxel_size_from_shape(shape: &RuntimeShape<u32, 3>) -> Vec3 {
     )
 }
 
-#[inline]
 fn map_nearest(position: UVec3, data_shape: UVec3) -> UVec3 {
     let to_index = |pos_i: u32, data_dim: u32| -> u32 {
         // scale the inner dimension of the padded shape
@@ -208,8 +207,7 @@ impl<I: Hash + Copy + PartialEq> ChunkData<I> {
                 return None;
             }
 
-            let reconstructed =
-                ((chunk_block - 1.0) * scale) as i32;
+            let reconstructed = ((chunk_block - 1.0) * scale) as i32;
 
             if reconstructed != component {
                 return None;
@@ -466,9 +464,12 @@ impl<C: VoxelWorldConfig + Send + Sync + 'static, I: Hash + Copy + Eq> ChunkTask
             let chunk_block = data_shape.delinearize(i);
 
             let block_pos = IVec3 {
-                x: ((chunk_block[0] as f32 - 1.0) * scale[0]) as i32 + (self.position.x * CHUNK_SIZE_I),
-                y: ((chunk_block[1] as f32 - 1.0) * scale[1]) as i32 + (self.position.y * CHUNK_SIZE_I),
-                z: ((chunk_block[2] as f32 - 1.0) * scale[2]) as i32 + (self.position.z * CHUNK_SIZE_I),
+                x: ((chunk_block[0] as f32 - 1.0) * scale[0]) as i32
+                    + (self.position.x * CHUNK_SIZE_I),
+                y: ((chunk_block[1] as f32 - 1.0) * scale[1]) as i32
+                    + (self.position.y * CHUNK_SIZE_I),
+                z: ((chunk_block[2] as f32 - 1.0) * scale[2]) as i32
+                    + (self.position.z * CHUNK_SIZE_I),
             };
 
             if let Some(voxel) = modified_voxels.get(&block_pos) {
@@ -480,12 +481,12 @@ impl<C: VoxelWorldConfig + Send + Sync + 'static, I: Hash + Copy + Eq> ChunkTask
             }
 
             let previous_voxel = previous_data.as_ref().and_then(|chunk| {
-                chunk
-                    .get_voxel_at_world_position(block_pos)
-                    .or_else(|| match chunk.get_fill_type() {
+                chunk.get_voxel_at_world_position(block_pos).or_else(|| {
+                    match chunk.get_fill_type() {
                         FillType::Uniform(voxel) => Some(*voxel),
                         _ => Some(WorldVoxel::Unset),
-                    })
+                    }
+                })
             });
 
             if reuse_previous {

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -132,8 +132,13 @@ impl<I: Hash + Copy + PartialEq> ChunkData<I> {
         }
     }
 
-    /// Get the voxel at the given position in the chunk
-    /// The position is given in local chunk data coordinates
+    /// Get the voxel at the given position in the chunk.
+    ///
+    /// The `position` is expressed in chunk-local **data** coordinates, meaning it
+    /// indexes directly into the padded `data_shape` associated with this chunk.
+    /// When using non-default LOD shapes, these coordinates may no longer map
+    /// 1:1 to world-space voxels. Prefer [`ChunkData::get_voxel_at_world_position`]
+    /// when you need to query by a world position.
     pub fn get_voxel(&self, position: UVec3) -> WorldVoxel<I> {
         if let Some(voxels) = &self.voxels {
             let shape = RuntimeShape::<u32, 3>::new(self.data_shape.to_array());

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -146,8 +146,12 @@ impl<I: Hash + Copy + PartialEq> ChunkData<I> {
     pub(crate) fn generate_hash(&mut self) {
         if let Some(voxels) = &self.voxels {
             let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            self.data_shape.to_array().hash(&mut hasher);
+            self.mesh_shape.to_array().hash(&mut hasher);
             voxels.hash(&mut hasher);
             self.voxels_hash = hasher.finish();
+        } else {
+            self.voxels_hash = 0;
         }
     }
 

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -157,19 +157,9 @@ impl<I: Hash + Copy + PartialEq> ChunkData<I> {
         &self,
         world_position: IVec3,
     ) -> Option<WorldVoxel<I>> {
-        let chunk_pos = IVec3 {
-            x: (world_position.x as f32 / CHUNK_SIZE_F).floor() as i32,
-            y: (world_position.y as f32 / CHUNK_SIZE_F).floor() as i32,
-            z: (world_position.z as f32 / CHUNK_SIZE_F).floor() as i32,
-        };
-
-        if chunk_pos != self.position {
-            return None;
-        }
-
         let shape = RuntimeShape::<u32, 3>::new(self.data_shape.to_array());
         let scale = voxel_size_from_shape(&shape);
-        let chunk_origin = chunk_pos * CHUNK_SIZE_I;
+        let chunk_origin = self.position * CHUNK_SIZE_I;
         let offset = world_position - chunk_origin;
 
         let to_index = |component: i32, scale: f32, max: u32| -> Option<u32> {
@@ -205,7 +195,7 @@ impl<I: Hash + Copy + PartialEq> ChunkData<I> {
             to_index(offset.z, scale.z, self.data_shape.z),
         ) {
             (Some(x), Some(y), Some(z)) => UVec3::new(x, y, z),
-            _ => return Some(WorldVoxel::Unset),
+            _ => return None,
         };
 
         Some(self.get_voxel(chunk_block))

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -173,7 +173,7 @@ pub trait VoxelWorldConfig: Resource + Default + Clone {
 
     /// Determine how voxel data should be regenerated for a chunk. Defaults to reusing previous data.
     fn chunk_regenerate_strategy(&self) -> ChunkRegenerateStrategy {
-        ChunkRegenerateStrategy::Reuse
+        ChunkRegenerateStrategy::default()
     }
 
     fn init_root(&self, mut _commands: Commands, _root: Entity) {}

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -25,12 +25,7 @@ pub const fn padded_chunk_shape_uniform(edge: u32) -> UVec3 {
 }
 
 pub type ChunkMeshingFn<I, UB> = Box<
-    dyn FnMut(
-            VoxelArray<I>,
-            UVec3,
-            UVec3,
-            TextureIndexMapperFn<I>,
-        ) -> (Mesh, Option<UB>)
+    dyn FnMut(VoxelArray<I>, UVec3, UVec3, TextureIndexMapperFn<I>) -> (Mesh, Option<UB>)
         + Send
         + Sync,
 >;

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -26,7 +26,7 @@ pub const fn padded_chunk_shape_uniform(edge: u32) -> UVec3 {
 
 pub type ChunkMeshingFn<I, UB> = Box<
     dyn FnMut(
-            Arc<VoxelArray<I>>,
+            VoxelArray<I>,
             UVec3,
             UVec3,
             TextureIndexMapperFn<I>,
@@ -218,7 +218,7 @@ pub fn default_chunk_meshing_delegate<I: PartialEq + Copy, UB: Bundle>(
     _previous_data: Option<ChunkData<I>>,
 ) -> ChunkMeshingFn<I, UB> {
     Box::new(
-        move |voxels: Arc<VoxelArray<I>>,
+        move |voxels: VoxelArray<I>,
               data_shape_in: UVec3,
               mesh_shape_in: UVec3,
               texture_index_mapper: TextureIndexMapperFn<I>| {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -221,6 +221,21 @@ pub trait VoxelWorldConfig: Resource + Default + Clone {
         ChunkRegenerateStrategy::default()
     }
 
+    /// Maximum number of chunk generation tasks that may be active simultaneously.
+    fn max_active_chunk_threads(&self) -> usize {
+        usize::MAX
+    }
+
+    /// Whether chunk entities should be parented to the world root entity.
+    ///
+    /// Parenting makes it easy to transform or hide the entire voxel world at once,
+    /// but it also forces Bevy's transform propagation system to walk the entire
+    /// hierarchy whenever chunks spawn/despawn. Worlds with large numbers of chunks
+    /// streaming into and out of view will perform better without a world_root.
+    fn attach_chunks_to_root(&self) -> bool {
+        true
+    }
+
     fn init_root(&self, mut _commands: Commands, _root: Entity) {}
 }
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -193,8 +193,16 @@ pub trait VoxelWorldConfig: Resource + Default + Clone {
     }
 
     /// Compute the level of detail for a chunk at a world-space position.
+    ///
+    /// `previous_lod` will be `None` when the chunk is first spawned and `Some(current_lod)`
+    /// when an existing chunk is being re-evaluated. Implementors can use this to add hysteresis.
     /// Defaults to `0` for all chunks.
-    fn chunk_lod(&self, _chunk_position: IVec3, _camera_position: Vec3) -> LodLevel {
+    fn chunk_lod(
+        &self,
+        _chunk_position: IVec3,
+        _previous_lod: Option<LodLevel>,
+        _camera_position: Vec3,
+    ) -> LodLevel {
         0
     }
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -48,12 +48,23 @@ pub type ChunkMeshingDelegate<I, UB> = Option<
     >,
 >;
 
+/// Controls how voxel payloads are handled when a chunk changes LOD.
+///
+/// `Reuse` keeps previously generated voxel data even when the requested
+/// `chunk_data_shape` shrinks. This avoids the cost of
+/// regenerating high-resolution data if the chunk is later promoted to a finer
+/// LOD at the expense of retaining the larger voxel buffer while the chunk is
+/// coarse.
+///
+/// `Repopulate` always rebuilds voxel data for the requested shape, discarding
+/// any excess high-resolution data so that downgraded chunks keep only the
+/// coarse payload.
 #[derive(Default, Clone, Copy, PartialEq, Eq)]
 pub enum ChunkRegenerateStrategy {
-    /// Attempt to reuse previously generated chunk data before invoking the voxel lookup delegate.
+    /// Attempt to reuse previously generated chunk data before invoking the voxel lookup delegate, retaining the existing voxel payload when possible.
     #[default]
     Reuse,
-    /// Always regenerate voxel data using the voxel lookup delegate.
+    /// Always regenerate voxel data using the voxel lookup delegate, discarding any higher-resolution data that is no longer needed.
     Repopulate,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,8 @@ pub mod prelude {
         get_chunk_voxel_position, VoxelRaycastResult, VoxelWorld, VoxelWorldCamera,
     };
     pub use crate::voxel_world::{
-        ChunkWillDespawn, ChunkWillRemesh, ChunkWillSpawn, ChunkWillUpdate,
+        ChunkWillChangeLod, ChunkWillDespawn, ChunkWillRemesh, ChunkWillSpawn,
+        ChunkWillUpdate,
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod custom_meshing {
     pub use crate::chunk::CHUNK_SIZE_I;
     pub use crate::chunk::CHUNK_SIZE_U;
     pub use crate::meshing::generate_chunk_mesh;
+    pub use crate::meshing::generate_chunk_mesh_for_shape;
     pub use crate::meshing::mesh_from_quads;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,12 +26,12 @@ pub mod prelude {
 
 pub mod custom_meshing {
     pub use crate::chunk::PaddedChunkShape;
+    pub use crate::chunk::VoxelArray;
     pub use crate::chunk::CHUNK_SIZE_F;
     pub use crate::chunk::CHUNK_SIZE_I;
     pub use crate::chunk::CHUNK_SIZE_U;
     pub use crate::meshing::generate_chunk_mesh;
     pub use crate::meshing::mesh_from_quads;
-    pub use crate::chunk::VoxelArray;
 }
 
 pub mod debug {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub mod custom_meshing {
     pub use crate::chunk::CHUNK_SIZE_U;
     pub use crate::meshing::generate_chunk_mesh;
     pub use crate::meshing::mesh_from_quads;
-    pub use crate::meshing::VoxelArray;
+    pub use crate::chunk::VoxelArray;
 }
 
 pub mod debug {

--- a/src/meshing.rs
+++ b/src/meshing.rs
@@ -128,10 +128,12 @@ fn mesh_from_quads_for_shape<I: PartialEq + Copy>(
             // TODO: Fix AO anisotropy
             indices.extend_from_slice(&face.quad_mesh_indices(positions.len() as u32));
 
+            let vec_one = BMVec3::new(1.0,1.0,1.0);
+
             positions.extend_from_slice(
                 &face
                     .quad_corners(&quad.into())
-                    .map(|c| (voxel_size * c.as_vec3()).to_array()),
+                    .map(|c| ((voxel_size * (c.as_vec3() - vec_one)) + vec_one).to_array()),
             );
 
             normals.extend_from_slice(&face.quad_mesh_normals());
@@ -197,7 +199,7 @@ fn mesh_from_quads_for_shape<I: PartialEq + Copy>(
 #[inline]
 fn map_nearest_1d(mesh_i: u32, mesh_dim: u32, data_dim: u32) -> u32 {
     // scale the inner dimension of the padded shape
-    let scale = (data_dim - 2) as f32 / (mesh_dim - 3) as f32;
+    let scale = (data_dim - 2) as f32 / (mesh_dim - 3).max(1) as f32;
     let mut s = (((mesh_i as f32 - 1.0) * scale).round() + 1.0) as i32;
     if s < 0 {
         s = 0;

--- a/src/meshing.rs
+++ b/src/meshing.rs
@@ -13,16 +13,14 @@ use bevy::{
     prelude::*,
     render::render_resource::PrimitiveTopology,
 };
-use ndshape::{ConstShape, RuntimeShape, Shape};
+use ndshape::{RuntimeShape, Shape};
 
 use crate::{
-    chunk::{PaddedChunkShape, CHUNK_SIZE_F, PADDED_CHUNK_SIZE},
+    chunk::{VoxelArray, CHUNK_SIZE_F, PADDED_CHUNK_SIZE},
     prelude::TextureIndexMapperFn,
     voxel::WorldVoxel,
     voxel_material::ATTRIBUTE_TEX_INDEX,
 };
-
-pub type VoxelArray<I> = Arc<[WorldVoxel<I>; PaddedChunkShape::SIZE as usize]>;
 
 /// Generate a mesh for the given chunks, or None of the chunk is empty
 pub fn generate_chunk_mesh<I: PartialEq + Copy>(

--- a/src/meshing.rs
+++ b/src/meshing.rs
@@ -128,12 +128,16 @@ fn mesh_from_quads_for_shape<I: PartialEq + Copy>(
             // TODO: Fix AO anisotropy
             indices.extend_from_slice(&face.quad_mesh_indices(positions.len() as u32));
 
-            let vec_one = BMVec3::new(1.0,1.0,1.0);
-
             positions.extend_from_slice(
                 &face
                     .quad_corners(&quad.into())
-                    .map(|c| ((voxel_size * (c.as_vec3() - vec_one)) + vec_one).to_array()),
+                    .map(|c| {
+                        let corner = c.as_vec3();
+                        let adjusted =
+                            voxel_size * (corner - BMVec3::splat(1.0))
+                                + BMVec3::splat(1.0);
+                        adjusted.to_array()
+                    }),
             );
 
             normals.extend_from_slice(&face.quad_mesh_normals());

--- a/src/meshing.rs
+++ b/src/meshing.rs
@@ -131,14 +131,12 @@ fn mesh_from_quads_for_shape<I: PartialEq + Copy>(
 
             let corners = face.quad_corners(&quad);
 
-            positions.extend_from_slice(
-                &corners.map(|c| {
-                    let corner = c.as_vec3();
-                    let adjusted =
-                        voxel_size * (corner - BMVec3::splat(1.0)) + BMVec3::splat(1.0);
-                    adjusted.to_array()
-                }),
-            );
+            positions.extend_from_slice(&corners.map(|c| {
+                let corner = c.as_vec3();
+                let adjusted =
+                    voxel_size * (corner - BMVec3::splat(1.0)) + BMVec3::splat(1.0);
+                adjusted.to_array()
+            }));
 
             normals.extend_from_slice(&face.quad_mesh_normals());
 

--- a/src/meshing.rs
+++ b/src/meshing.rs
@@ -203,7 +203,7 @@ fn mesh_from_quads_for_shape<I: PartialEq + Copy>(
 #[inline]
 fn map_nearest_1d(mesh_i: u32, mesh_dim: u32, data_dim: u32) -> u32 {
     // scale the inner dimension of the padded shape
-    let scale = (data_dim - 2) as f32 / (mesh_dim - 3).max(1) as f32;
+    let scale = (data_dim as f32 - 2.0) / (mesh_dim as f32 - 3.0).max(1.0);
     let mut s = (((mesh_i as f32 - 1.0) * scale).round() + 1.0) as i32;
     if s < 0 {
         s = 0;

--- a/src/meshing.rs
+++ b/src/meshing.rs
@@ -16,7 +16,7 @@ use bevy::{
 use ndshape::{ConstShape, RuntimeShape, Shape};
 
 use crate::{
-    chunk::{CHUNK_SIZE_F, PADDED_CHUNK_SIZE, PaddedChunkShape},
+    chunk::{PaddedChunkShape, CHUNK_SIZE_F, PADDED_CHUNK_SIZE},
     prelude::TextureIndexMapperFn,
     voxel::WorldVoxel,
     voxel_material::ATTRIBUTE_TEX_INDEX,
@@ -54,7 +54,8 @@ pub fn generate_chunk_mesh_for_shape<I: PartialEq + Copy>(
     let data_shape = RuntimeShape::<u32, 3>::new(data_padded_shape.to_array());
     let mesh_shape = RuntimeShape::<u32, 3>::new(mesh_padded_shape.to_array());
 
-    let voxels_for_mesh: Arc<[WorldVoxel<I>]> = if data_padded_shape != mesh_padded_shape {
+    let voxels_for_mesh: Arc<[WorldVoxel<I>]> = if data_padded_shape != mesh_padded_shape
+    {
         let coarse = resample_voxels_nearest(voxels.as_ref(), &data_shape, &mesh_shape);
         Arc::<[WorldVoxel<I>]>::from(coarse)
     } else {
@@ -93,13 +94,7 @@ pub fn mesh_from_quads<I: PartialEq + Copy>(
     texture_index_mapper: Arc<dyn Fn(I) -> [u32; 3] + Send + Sync>,
 ) -> Mesh {
     let shape = RuntimeShape::<u32, 3>::new([PADDED_CHUNK_SIZE; 3]);
-    mesh_from_quads_for_shape(
-        quads,
-        faces,
-        voxels.as_ref(),
-        texture_index_mapper,
-        &shape,
-    )
+    mesh_from_quads_for_shape(quads, faces, voxels.as_ref(), texture_index_mapper, &shape)
 }
 
 fn mesh_from_quads_for_shape<I: PartialEq + Copy>(
@@ -135,8 +130,11 @@ fn mesh_from_quads_for_shape<I: PartialEq + Copy>(
             // TODO: Fix AO anisotropy
             indices.extend_from_slice(&face.quad_mesh_indices(positions.len() as u32));
 
-            positions.extend_from_slice(&face.quad_corners(&quad.into())
-            .map(|c| (voxel_size * c.as_vec3()).to_array()));
+            positions.extend_from_slice(
+                &face
+                    .quad_corners(&quad.into())
+                    .map(|c| (voxel_size * c.as_vec3()).to_array()),
+            );
 
             normals.extend_from_slice(&face.quad_mesh_normals());
 
@@ -203,9 +201,13 @@ fn map_nearest_1d(mesh_i: u32, mesh_dim: u32, data_dim: u32) -> u32 {
     // scale the inner dimension of the padded shape
     let scale = (data_dim - 2) as f32 / (mesh_dim - 3) as f32;
     let mut s = (((mesh_i as f32 - 1.0) * scale).round() + 1.0) as i32;
-    if s < 0 { s = 0; }
+    if s < 0 {
+        s = 0;
+    }
     let max = (data_dim as i32 - 1).max(0);
-    if s > max { s = max; }
+    if s > max {
+        s = max;
+    }
     s as u32
 }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -8,7 +8,7 @@ use bevy::{
 use crate::{
     configuration::{DefaultWorld, VoxelWorldConfig},
     voxel_material::{
-        prepare_texture, LoadingTexture, StandardVoxelMaterial, TextureLayers,
+        prepare_texture, set_repeat_sampler, LoadingTexture, StandardVoxelMaterial, TextureLayers,
         VOXEL_TEXTURE_SHADER_HANDLE,
     },
     voxel_world::*,
@@ -179,6 +179,7 @@ where
                         RenderAssetUsages::default(),
                     )
                     .unwrap();
+                    set_repeat_sampler(&mut image);
                     image.reinterpret_stacked_2d_as_array(4);
                     let mut image_assets =
                         app.world_mut().resource_mut::<Assets<Image>>();

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -8,8 +8,8 @@ use bevy::{
 use crate::{
     configuration::{DefaultWorld, VoxelWorldConfig},
     voxel_material::{
-        prepare_texture, set_repeat_sampler, LoadingTexture, StandardVoxelMaterial, TextureLayers,
-        VOXEL_TEXTURE_SHADER_HANDLE,
+        prepare_texture, set_repeat_sampler, LoadingTexture, StandardVoxelMaterial,
+        TextureLayers, VOXEL_TEXTURE_SHADER_HANDLE,
     },
     voxel_world::*,
     voxel_world_internal::Internals,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -126,6 +126,7 @@ where
             .add_message::<ChunkWillSpawn<C>>()
             .add_message::<ChunkWillDespawn<C>>()
             .add_message::<ChunkWillRemesh<C>>()
+            .add_message::<ChunkWillChangeLod<C>>()
             .add_message::<ChunkWillUpdate<C>>();
 
         // Spawning of meshes is optional, mainly to simplify testing.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -103,7 +103,11 @@ where
                 PreUpdate,
                 (
                     (
-                        (Internals::<C>::spawn_chunks, Internals::<C>::retire_chunks)
+                        (
+                            Internals::<C>::spawn_chunks,
+                            Internals::<C>::update_chunk_lods,
+                            Internals::<C>::retire_chunks,
+                        )
                             .chain(),
                         Internals::<C>::remesh_dirty_chunks,
                     )

--- a/src/test.rs
+++ b/src/test.rs
@@ -234,6 +234,7 @@ fn raycast_finds_voxel() {
                 IVec3::new(0, 0, 0),
                 ChunkData {
                     position: IVec3::new(0, 0, 0),
+                    lod_level: 0,
                     voxels: Some(std::sync::Arc::new([WorldVoxel::Unset; 39304])),
                     voxels_hash: 0,
                     is_full: false,

--- a/src/test.rs
+++ b/src/test.rs
@@ -8,8 +8,8 @@ use crate::voxel_traversal::voxel_line_traversal;
 use crate::{
     chunk::{ChunkData, ChunkTask, FillType, PADDED_CHUNK_SIZE},
     prelude::VoxelWorldCamera,
-    voxel_world_internal::ModifiedVoxels,
     voxel_world::*,
+    voxel_world_internal::ModifiedVoxels,
 };
 use ndshape::{RuntimeShape, Shape};
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -5,7 +5,7 @@ use crate::mesh_cache::MeshCacheInsertBuffer;
 use crate::prelude::*;
 use crate::voxel_traversal::voxel_line_traversal;
 use crate::{
-    chunk::{ChunkData, FillType},
+    chunk::{ChunkData, FillType, PADDED_CHUNK_SIZE},
     prelude::VoxelWorldCamera,
     voxel_world::*,
 };
@@ -242,6 +242,8 @@ fn raycast_finds_voxel() {
                     fill_type: FillType::Mixed,
                     entity: Entity::PLACEHOLDER,
                     has_generated: false,
+                    data_shape: UVec3::splat(PADDED_CHUNK_SIZE),
+                    mesh_shape: UVec3::splat(PADDED_CHUNK_SIZE),
                 },
                 ChunkWillSpawn::<DefaultWorld>::new(
                     IVec3::new(0, 0, 0),

--- a/src/test.rs
+++ b/src/test.rs
@@ -3,9 +3,10 @@ use bevy::prelude::*;
 use std::sync::Arc;
 
 use crate::chunk_map::ChunkMapUpdateBuffer;
+use crate::configuration::VoxelWorldConfig;
 use crate::mesh_cache::MeshCacheInsertBuffer;
-use crate::prelude::*;
 use crate::meshing::generate_chunk_mesh_for_shape;
+use crate::prelude::*;
 use crate::voxel_traversal::voxel_line_traversal;
 use crate::{
     chunk::{ChunkData, ChunkTask, FillType, CHUNK_SIZE_F, PADDED_CHUNK_SIZE},

--- a/src/voxel_material.rs
+++ b/src/voxel_material.rs
@@ -8,6 +8,7 @@ use bevy::{
         AsBindGroup, RenderPipelineDescriptor, SpecializedMeshPipelineError, VertexFormat,
     },
 };
+use bevy::image::ImageAddressMode;
 use bevy_shader::{Shader, ShaderDefVal, ShaderRef};
 
 /// Keeps track of the loading status of the image used for the voxel texture
@@ -92,5 +93,13 @@ pub(crate) fn prepare_texture(
     loading_texture.is_loaded = true;
 
     let image = images.get_mut(&loading_texture.handle).unwrap();
+    set_repeat_sampler(image);
     image.reinterpret_stacked_2d_as_array(texture_layers.0);
+}
+
+pub(crate) fn set_repeat_sampler(image: &mut Image) {
+    let descriptor = image.sampler.get_or_init_descriptor();
+    descriptor.address_mode_u = ImageAddressMode::Repeat;
+    descriptor.address_mode_v = ImageAddressMode::Repeat;
+    descriptor.address_mode_w = ImageAddressMode::Repeat;
 }

--- a/src/voxel_material.rs
+++ b/src/voxel_material.rs
@@ -1,3 +1,4 @@
+use bevy::image::ImageAddressMode;
 use bevy::{
     asset::uuid_handle,
     mesh::{MeshVertexAttribute, MeshVertexBufferLayoutRef, VertexAttributeDescriptor},
@@ -8,7 +9,6 @@ use bevy::{
         AsBindGroup, RenderPipelineDescriptor, SpecializedMeshPipelineError, VertexFormat,
     },
 };
-use bevy::image::ImageAddressMode;
 use bevy_shader::{Shader, ShaderDefVal, ShaderRef};
 
 /// Keeps track of the loading status of the image used for the voxel texture

--- a/src/voxel_world.rs
+++ b/src/voxel_world.rs
@@ -88,6 +88,11 @@ pub type ChunkWillRemesh<C> = ChunkEvent<C, WillRemesh>;
 pub struct WillRemesh;
 impl ChunkEventType for WillRemesh {}
 
+/// Fired when a chunk's LOD value changes.
+pub type ChunkWillChangeLod<C> = ChunkEvent<C, WillChangeLod>;
+pub struct WillChangeLod;
+impl ChunkEventType for WillChangeLod {}
+
 /// Fired when a chunk is about to be updated, typically when `set_voxel` was called on a voxel
 /// within the chunk.
 pub type ChunkWillUpdate<C> = ChunkEvent<C, WillUpdate>;

--- a/src/voxel_world.rs
+++ b/src/voxel_world.rs
@@ -159,7 +159,7 @@ impl<C: VoxelWorldConfig> VoxelWorld<'_, C> {
         let modified_voxels = self.modified_voxels.clone();
 
         Arc::new(move |position| {
-            let (chunk_pos, vox_pos) = get_chunk_voxel_position(position);
+            let (chunk_pos, _) = get_chunk_voxel_position(position);
 
             if let Some(voxel) = write_buffer
                 .iter()
@@ -180,11 +180,9 @@ impl<C: VoxelWorldConfig> VoxelWorld<'_, C> {
                 chun_map_read.get(&chunk_pos).cloned()
             };
 
-            if let Some(chunk_data) = chunk_opt {
-                chunk_data.get_voxel(vox_pos)
-            } else {
-                WorldVoxel::Unset
-            }
+            chunk_opt
+                .and_then(|chunk_data| chunk_data.get_voxel_at_world_position(position))
+                .unwrap_or(WorldVoxel::Unset)
         })
     }
 

--- a/src/voxel_world_internal.rs
+++ b/src/voxel_world_internal.rs
@@ -361,6 +361,8 @@ where
 
             let lod_level = chunk.lod_level;
 
+            let regenerate_strategy = configuration.chunk_regenerate_strategy();
+
             let voxel_data_fn = (configuration.voxel_lookup_delegate())(
                 chunk.position,
                 lod_level,
@@ -384,8 +386,14 @@ where
 
             let mesh_map = mesh_cache.get_mesh_map();
 
+            let previous_for_generate = previous_chunk_data.clone();
+
             let thread = thread_pool.spawn(async move {
-                chunk_task.generate(voxel_data_fn);
+                chunk_task.generate(
+                    voxel_data_fn,
+                    previous_for_generate,
+                    regenerate_strategy,
+                );
 
                 // No need to mesh if the chunk is empty or full
                 if chunk_task.is_empty() || chunk_task.is_full() {

--- a/src/voxel_world_internal.rs
+++ b/src/voxel_world_internal.rs
@@ -109,7 +109,8 @@ where
         let Ok((camera, cam_gtf)) = camera_info.single() else {
             return;
         };
-        let cam_pos = cam_gtf.translation().as_ivec3();
+        let camera_position = cam_gtf.translation();
+        let cam_pos = camera_position.as_ivec3();
 
         let spawning_distance = configuration.spawning_distance() as i32;
         let spawning_distance_squared = spawning_distance.pow(2);

--- a/src/voxel_world_internal.rs
+++ b/src/voxel_world_internal.rs
@@ -395,6 +395,7 @@ where
 
     /// Spawn a thread for each chunk that has been marked by NeedsRemesh
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::type_complexity)]
     pub fn remesh_dirty_chunks(
         mut commands: Commands,
         mut ev_chunk_will_remesh: MessageWriter<ChunkWillRemesh<C>>,

--- a/src/voxel_world_internal.rs
+++ b/src/voxel_world_internal.rs
@@ -203,7 +203,8 @@ where
             if !has_chunk {
                 let chunk_entity = commands.spawn(NeedsRemesh).id();
                 commands.entity(world_root).add_child(chunk_entity);
-                let lod_level = configuration.chunk_lod(chunk_position, camera_position);
+                let lod_level =
+                    configuration.chunk_lod(chunk_position, None, camera_position);
                 let data_shape = configuration.chunk_data_shape(lod_level);
                 let mesh_shape = configuration.chunk_meshing_shape(lod_level);
                 let chunk = Chunk::<C>::new(
@@ -263,7 +264,8 @@ where
         let camera_position = cam_gtf.translation();
 
         for (entity, mut chunk) in chunks.iter_mut() {
-            let target_lod = configuration.chunk_lod(chunk.position, camera_position);
+            let target_lod = configuration
+                .chunk_lod(chunk.position, Some(chunk.lod_level), camera_position);
             if target_lod == chunk.lod_level {
                 continue;
             }

--- a/src/voxel_world_internal.rs
+++ b/src/voxel_world_internal.rs
@@ -386,12 +386,10 @@ where
 
             let mesh_map = mesh_cache.get_mesh_map();
 
-            let previous_for_generate = previous_chunk_data.clone();
-
             let thread = thread_pool.spawn(async move {
                 chunk_task.generate(
                     voxel_data_fn,
-                    previous_for_generate,
+                    previous_chunk_data.clone(),
                     regenerate_strategy,
                 );
 


### PR DESCRIPTION
This PR adds opt-in, per-chunk level-of-detail (LOD) support to `bevy_voxel_world` while keeping existing worlds unchanged by default. Chunks can now be generated and meshed at different resolutions depending on camera distance or any custom heuristic, and both voxel generation and meshing get additional context to reuse previous data when LOD changes.

### Overview

- Add `VoxelWorldConfig::chunk_lod` to compute a `LodLevel` per chunk from its world position, previous LOD, and camera position.
- Extend `Chunk` / `ChunkData` with `lod_level`, `data_shape`, and `mesh_shape`, plus helpers for padded shapes (`padded_chunk_shape`, `padded_chunk_shape_uniform`).
- Allow LOD-dependent voxel resolutions via `chunk_data_shape(lod)` and `chunk_meshing_shape(lod)`, plus a new `generate_chunk_mesh_for_shape` and resampling to keep meshes visually consistent regardless of shape.
- Add `ChunkRegenerateStrategy` and `chunk_regenerate_strategy()` to control whether existing voxel buffers are reused or regenerated when LOD changes.
- Add `max_active_chunk_threads()` and `attach_chunks_to_root()` knobs for better control over task-pool pressure and transform hierarchy costs.
- Introduce a new `ChunkWillChangeLod` event and document the feature in the README, including a new `examples/noise_terrain_lod.rs` that demonstrates varying shapes and using skirts to hide LOD seams.

## Breaking changes (package users)

These are the user-facing API changes that require code updates when upgrading:

- `VoxelWorldConfig::voxel_lookup_delegate` now returns a `VoxelLookupDelegate<I>` with the signature:

  ```rust
  pub type VoxelLookupDelegate<I = u8> =
      Box<dyn Fn(IVec3, LodLevel, Option<ChunkData<I>>) -> VoxelLookupFn<I> + Send + Sync>;

  pub type VoxelLookupFn<I = u8> =
      Box<dyn FnMut(IVec3, Option<WorldVoxel<I>>) -> WorldVoxel<I> + Send + Sync>;

Any custom `voxel_lookup_delegate` must be updated to accept `(chunk_pos, lod_level, previous_chunk_data)` and produce an inner closure that accepts `(world_pos, previous_voxel)` (you can ignore the extra arguments if you don’t need them, as the examples do).

- `VoxelWorldConfig::chunk_meshing_delegate` now returns a `ChunkMeshingDelegate<I, UB>` that is parameterized by LOD, data shape, mesh shape, and previous data:

  ```rust
  pub type ChunkMeshingFn<I, UB> = Box<
      dyn FnMut(VoxelArray<I>, UVec3, UVec3, TextureIndexMapperFn<I>) -> (Mesh, Option<UB>)
          + Send
          + Sync,
  >;

  pub type ChunkMeshingDelegate<I, UB> = Option<
      Box<
          dyn Fn(
                  IVec3,
                  LodLevel,
                  UVec3,
                  UVec3,
                  Option<ChunkData<I>>,
              ) -> ChunkMeshingFn<I, UB>
              + Send
              + Sync,
      >,
  >;

Custom meshing delegates must adapt to this signature, but can ignore the new parameters when not using LOD. The `custom_meshing` example shows the updated pattern.

`ChunkData` and `Chunk` now treat `data_shape` as the authoritative voxel grid for a chunk. Existing code that assumed a fixed `PADDED_CHUNK_SIZE` should either keep using the defaults (no change) or read the accessor methods (`data_shape()`, `mesh_shape()`, `lod_level()`) instead of hardcoding dimensions. From a user’s perspective, voxel access still happens in world space: `VoxelLookupFn` is always invoked with positions on the fixed `CHUNK_SIZE` world grid, and when reading existing data you should prefer `ChunkData::get_voxel_at_world_position`, which likewise takes world-space positions and hides the current `data_shape` behind a stable `CHUNK_SIZE`-based layout.

## Notes

LOD is completely opt-in: if you do not override chunk_lod, chunk_data_shape, or chunk_meshing_shape, the world behaves the same as before.

The new noise_terrain_lod example, README “Level of Detail” section, and tests around generate_chunk_mesh_for_shape document the intended usage and invariants (chunks still occupy the same world-space extent regardless of shape).

This PR is related to #3.