### PR TITLE
Remesh adjacent chunks after boundary voxel edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.15.2
+
+- Fix: `set_voxel` now queues loaded neighboring chunks for remeshing when a changed voxel is part of their padded chunk data. This keeps meshes correct across chunk boundaries without requiring user code to manually mark adjacent chunks.
+
 ## 0.15.1
 
 - Fix: `set_voxel` no longer triggers a chunk remesh when the written value is identical to the current value. Previously, writing the same voxel value every frame would cause perpetual remesh cancellation — the in-progress async meshing task was dropped each frame before completion, preventing the chunk from ever rendering.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_voxel_world"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "ahash 0.8.12",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_voxel_world"
 description = "A voxel world plugin for Bevy"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 authors = ["Joacim Magnusson <joacim@isogram.se>"]
 license = "MIT OR Apache-2.0"

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,15 +1,19 @@
 use bevy::mesh::VertexAttributeValues;
 use bevy::prelude::*;
-use std::sync::Arc;
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
 
-use crate::chunk_map::ChunkMapUpdateBuffer;
+use crate::chunk_map::{ChunkMapInsertBuffer, ChunkMapUpdateBuffer};
 use crate::configuration::VoxelWorldConfig;
 use crate::mesh_cache::MeshCacheInsertBuffer;
 use crate::meshing::generate_chunk_mesh_for_shape;
 use crate::prelude::*;
 use crate::voxel_traversal::voxel_line_traversal;
 use crate::{
-    chunk::{ChunkData, ChunkTask, FillType, CHUNK_SIZE_F, PADDED_CHUNK_SIZE},
+    chunk::{
+        Chunk, ChunkData, ChunkTask, FillType, CHUNK_SIZE_F, CHUNK_SIZE_I,
+        PADDED_CHUNK_SIZE,
+    },
     prelude::VoxelWorldCamera,
     voxel_world::*,
     voxel_world_internal::ModifiedVoxels,
@@ -206,6 +210,126 @@ fn chunk_will_update_event() {
     );
 
     app.update();
+}
+
+#[test]
+fn affected_chunk_positions_include_padding_neighbors() {
+    let affected: HashSet<_> = get_affected_chunk_positions(IVec3::new(0, 0, 0))
+        .into_iter()
+        .collect();
+    let expected = HashSet::from([
+        IVec3::new(0, 0, 0),
+        IVec3::new(0, 0, -1),
+        IVec3::new(0, -1, 0),
+        IVec3::new(0, -1, -1),
+        IVec3::new(-1, 0, 0),
+        IVec3::new(-1, 0, -1),
+        IVec3::new(-1, -1, 0),
+        IVec3::new(-1, -1, -1),
+    ]);
+
+    assert_eq!(affected, expected);
+
+    assert_eq!(
+        get_affected_chunk_positions(IVec3::new(1, 1, 1)),
+        vec![IVec3::new(0, 0, 0)]
+    );
+
+    let affected: HashSet<_> =
+        get_affected_chunk_positions(IVec3::new(CHUNK_SIZE_I - 1, 1, 1))
+            .into_iter()
+            .collect();
+    let expected = HashSet::from([IVec3::new(0, 0, 0), IVec3::new(1, 0, 0)]);
+
+    assert_eq!(affected, expected);
+}
+
+#[test]
+fn set_voxel_on_chunk_boundary_marks_padding_neighbors_for_remesh() {
+    let expected = HashSet::from([
+        IVec3::new(0, 0, 0),
+        IVec3::new(0, 0, -1),
+        IVec3::new(0, -1, 0),
+        IVec3::new(0, -1, -1),
+        IVec3::new(-1, 0, 0),
+        IVec3::new(-1, 0, -1),
+        IVec3::new(-1, -1, 0),
+        IVec3::new(-1, -1, -1),
+    ]);
+
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, VoxelWorldPlugin::<DefaultWorld>::minimal()));
+    let camera_transform =
+        Transform::from_xyz(10.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y);
+    app.world_mut().spawn((
+        Camera::default(),
+        Camera3d::default(),
+        camera_transform,
+        GlobalTransform::from(camera_transform),
+        VoxelWorldCamera::<DefaultWorld>::default(),
+    ));
+    app.update();
+
+    type Mat = <DefaultWorld as VoxelWorldConfig>::MaterialIndex;
+    let mut chunks = Vec::new();
+    for chunk_pos in expected.iter().copied() {
+        let entity = app.world_mut().spawn_empty().id();
+        let shape = UVec3::splat(PADDED_CHUNK_SIZE);
+        app.world_mut()
+            .entity_mut(entity)
+            .insert(Chunk::<DefaultWorld>::new(
+                chunk_pos, 0, entity, shape, shape,
+            ));
+        chunks.push((chunk_pos, ChunkData::<Mat>::with_entity(entity)));
+    }
+
+    app.world_mut()
+        .resource_mut::<ChunkMapInsertBuffer<DefaultWorld, Mat>>()
+        .extend(chunks);
+    app.update();
+    for _ in 0..100 {
+        app.update();
+    }
+
+    app.world_mut()
+        .resource_mut::<Messages<ChunkWillRemesh<DefaultWorld>>>()
+        .clear();
+
+    let remeshed_chunks = Arc::new(Mutex::new(Vec::new()));
+    let remeshed_chunks_writer = remeshed_chunks.clone();
+    app.add_systems(
+        Update,
+        move |mut events: MessageReader<ChunkWillRemesh<DefaultWorld>>| {
+            remeshed_chunks_writer
+                .lock()
+                .unwrap()
+                .extend(events.read().map(|event| event.chunk_key));
+        },
+    );
+
+    app.add_systems(
+        Update,
+        |mut voxel_world: VoxelWorld<DefaultWorld>, mut did_set: Local<bool>| {
+            if *did_set {
+                return;
+            }
+
+            voxel_world.set_voxel(IVec3::new(0, 0, 0), WorldVoxel::Solid(1));
+            *did_set = true;
+        },
+    );
+
+    app.update();
+    app.update();
+    app.update();
+
+    let remeshed_chunks: HashSet<_> =
+        remeshed_chunks.lock().unwrap().iter().copied().collect();
+
+    assert!(
+        expected.is_subset(&remeshed_chunks),
+        "expected {expected:?} to be remeshed, got {remeshed_chunks:?}"
+    );
 }
 
 #[test]

--- a/src/voxel_world.rs
+++ b/src/voxel_world.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use bevy::{ecs::system::SystemParam, math::bounding::RayCast3d, prelude::*};
 
 use crate::{
-    chunk::{ChunkData, CHUNK_SIZE_F, CHUNK_SIZE_I},
+    chunk::{ChunkData, CHUNK_SIZE_F, CHUNK_SIZE_I, CHUNK_SIZE_U},
     chunk_map::ChunkMap,
     configuration::VoxelWorldConfig,
     traversal_alg::voxel_line_traversal,
@@ -403,4 +403,39 @@ pub fn get_chunk_voxel_position(position: IVec3) -> (IVec3, UVec3) {
     let voxel_position = (position - chunk_position * CHUNK_SIZE_I).as_uvec3() + 1;
 
     (chunk_position, voxel_position)
+}
+
+/// Returns every chunk whose padded voxel data includes the given world-space voxel.
+pub(crate) fn get_affected_chunk_positions(position: IVec3) -> Vec<IVec3> {
+    let (chunk_position, voxel_position) = get_chunk_voxel_position(position);
+
+    let axis_offsets = |component| {
+        let mut offsets = [0, 0, 0];
+        let mut len = 1;
+
+        if component == 1 {
+            offsets[len] = -1;
+            len += 1;
+        }
+        if component == CHUNK_SIZE_U {
+            offsets[len] = 1;
+            len += 1;
+        }
+
+        (offsets, len)
+    };
+
+    let (x_offsets, x_len) = axis_offsets(voxel_position.x);
+    let (y_offsets, y_len) = axis_offsets(voxel_position.y);
+    let (z_offsets, z_len) = axis_offsets(voxel_position.z);
+    let mut affected_chunks = Vec::with_capacity(8);
+    for x in x_offsets.iter().take(x_len).copied() {
+        for y in y_offsets.iter().take(y_len).copied() {
+            for z in z_offsets.iter().take(z_len).copied() {
+                affected_chunks.push(chunk_position + IVec3::new(x, y, z));
+            }
+        }
+    }
+
+    affected_chunks
 }

--- a/src/voxel_world_internal.rs
+++ b/src/voxel_world_internal.rs
@@ -25,8 +25,8 @@ use crate::{
     voxel::WorldVoxel,
     voxel_material::LoadingTexture,
     voxel_world::{
-        get_chunk_voxel_position, ChunkWillChangeLod, ChunkWillDespawn, ChunkWillRemesh,
-        ChunkWillSpawn, ChunkWillUpdate, VoxelWorldCamera,
+        get_affected_chunk_positions, ChunkWillChangeLod, ChunkWillDespawn,
+        ChunkWillRemesh, ChunkWillSpawn, ChunkWillUpdate, VoxelWorldCamera,
     },
 };
 
@@ -621,17 +621,18 @@ where
                 continue;
             }
 
-            let (chunk_pos, _vox_pos) = get_chunk_voxel_position(*position);
             modified_voxels.insert(*position, *voxel);
 
-            // Mark the chunk as needing remeshing or spawn a new chunk if it doesn't exist
-            if let Some(chunk_data) =
-                ChunkMap::<C, C::MaterialIndex>::get(&chunk_pos, &chunk_map_read_lock)
-            {
-                if let Ok(mut ent) = commands.get_entity(chunk_data.entity) {
-                    ent.try_insert(NeedsRemesh);
-                    ent.remove::<ChunkThread<C, C::MaterialIndex>>();
-                    updated_chunks.insert((chunk_data.entity, chunk_pos));
+            for affected_chunk_pos in get_affected_chunk_positions(*position) {
+                if let Some(chunk_data) = ChunkMap::<C, C::MaterialIndex>::get(
+                    &affected_chunk_pos,
+                    &chunk_map_read_lock,
+                ) {
+                    if let Ok(mut ent) = commands.get_entity(chunk_data.entity) {
+                        ent.try_insert(NeedsRemesh);
+                        ent.remove::<ChunkThread<C, C::MaterialIndex>>();
+                        updated_chunks.insert((chunk_data.entity, affected_chunk_pos));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Updates `set_voxel` so edits on chunk boundaries also queue any loaded neighboring chunks that share the changed voxel through their padded data.

This keeps meshes correct across chunk edges without requiring user code to manually mark adjacent chunks for remeshing.
