### PR TITLE
Add wasm support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,6 +1564,7 @@ dependencies = [
  "bevy_shader",
  "block-mesh",
  "futures-lite",
+ "getrandom 0.3.4",
  "hashbrown 0.16.1",
  "ndshape",
  "noise",
@@ -2543,9 +2544,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,9 @@ ndshape = "0.3.0"
 rand = "0.9.2"
 weak-table = { version = "0.3.2", features = ["ahash"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.3", features = ["wasm_js"] }
+
 [dev-dependencies]
 bevy_northstar = { version = "0.6.1" }
 bevy_panorbit_camera = { version = "0.34.0" }


### PR DESCRIPTION
Adds the `getrandom` WASM JS backend for `wasm32` builds so `bevy_voxel_world` can compile for browser targets.

Bevy already provides most of the browser/WASM platform support in recent versions. 

I've only tested it as far as some experiments during bevy-jam.

Closes #15.

Future work: tune or add dedicated WASM examples with browser-friendly chunk spawning/thread limits, since the existing defaults don't perform well in browser but it's not too difficult to find settings that are stable.