### PR TITLE
Fix single-layer voxel texture arrays

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -8,7 +8,7 @@ use bevy::{
 use crate::{
     configuration::{DefaultWorld, VoxelWorldConfig},
     voxel_material::{
-        prepare_texture, set_repeat_sampler, LoadingTexture, StandardVoxelMaterial,
+        prepare_texture, prepare_voxel_texture, LoadingTexture, StandardVoxelMaterial,
         TextureLayers, VOXEL_TEXTURE_SHADER_HANDLE,
     },
     voxel_world::*,
@@ -178,8 +178,9 @@ where
                         RenderAssetUsages::default(),
                     )
                     .unwrap();
-                    set_repeat_sampler(&mut image);
-                    let _ = image.reinterpret_stacked_2d_as_array(4);
+                    prepare_voxel_texture(&mut image, 4).expect(
+                        "default voxel texture should be a valid 4-layer array texture",
+                    );
                     let mut image_assets =
                         app.world_mut().resource_mut::<Assets<Image>>();
                     image_assets.add(image)

--- a/src/voxel_material.rs
+++ b/src/voxel_material.rs
@@ -99,14 +99,11 @@ pub(crate) fn prepare_texture(
     }
 
     let image = images.get_mut(&loading_texture.handle).unwrap();
-    match prepare_voxel_texture(image, texture_layers.0) {
-        Ok(()) => {
-            loading_texture.is_loaded = true;
-        }
-        Err(err) => {
-            warn_once!("Failed to prepare voxel texture as a texture array: {err}");
-        }
+    if let Err(err) = prepare_voxel_texture(image, texture_layers.0) {
+        warn_once!("Failed to prepare voxel texture as a texture array: {err}");
     }
+
+    loading_texture.is_loaded = true;
 }
 
 pub(crate) fn prepare_voxel_texture(

--- a/src/voxel_material.rs
+++ b/src/voxel_material.rs
@@ -1,4 +1,4 @@
-use bevy::image::ImageAddressMode;
+use bevy::image::{ImageAddressMode, TextureReinterpretationError};
 use bevy::{
     asset::uuid_handle,
     mesh::{MeshVertexAttribute, MeshVertexBufferLayoutRef, VertexAttributeDescriptor},
@@ -6,7 +6,8 @@ use bevy::{
     prelude::*,
     reflect::TypePath,
     render::render_resource::{
-        AsBindGroup, RenderPipelineDescriptor, SpecializedMeshPipelineError, VertexFormat,
+        AsBindGroup, RenderPipelineDescriptor, SpecializedMeshPipelineError,
+        TextureViewDescriptor, TextureViewDimension, VertexFormat,
     },
 };
 use bevy_shader::{Shader, ShaderDefVal, ShaderRef};
@@ -96,11 +97,30 @@ pub(crate) fn prepare_texture(
     {
         return;
     }
-    loading_texture.is_loaded = true;
 
     let image = images.get_mut(&loading_texture.handle).unwrap();
+    match prepare_voxel_texture(image, texture_layers.0) {
+        Ok(()) => {
+            loading_texture.is_loaded = true;
+        }
+        Err(err) => {
+            warn_once!("Failed to prepare voxel texture as a texture array: {err}");
+        }
+    }
+}
+
+pub(crate) fn prepare_voxel_texture(
+    image: &mut Image,
+    texture_layers: u32,
+) -> Result<(), TextureReinterpretationError> {
     set_repeat_sampler(image);
-    let _ = image.reinterpret_stacked_2d_as_array(texture_layers.0);
+    image.reinterpret_stacked_2d_as_array(texture_layers)?;
+    image.texture_view_descriptor = Some(TextureViewDescriptor {
+        dimension: Some(TextureViewDimension::D2Array),
+        ..default()
+    });
+
+    Ok(())
 }
 
 pub(crate) fn set_repeat_sampler(image: &mut Image) {


### PR DESCRIPTION
Allows custom voxel textures with a single texture index.

When a stacked texture has one layer, Bevy can create a plain 2D texture view by default. This explicitly prepares voxel textures as 2d_array views so they match the voxel shader, including the one-layer case.

Closes #85.