### PR TITLE
More than one VoxelWorldCamera per world

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ name = "multiple_noise_terrain"
 path = "examples/multiple_noise_terrain.rs"
 
 [[example]]
+name = "multiple_cameras"
+path = "examples/multiple_cameras.rs"
+
+[[example]]
 name = "navigation"
 path = "examples/navigation.rs"
 

--- a/examples/multiple_cameras.rs
+++ b/examples/multiple_cameras.rs
@@ -5,8 +5,13 @@ use bevy::{
     light::CascadeShadowConfigBuilder,
     platform::collections::HashMap,
     prelude::*,
+    text::DEFAULT_FONT_DATA,
+    ui::{PositionType, Val},
 };
-use bevy_voxel_world::{custom_meshing::{CHUNK_SIZE_F, CHUNK_SIZE_U}, prelude::*};
+use bevy_voxel_world::{
+    custom_meshing::{CHUNK_SIZE_F, CHUNK_SIZE_U},
+    prelude::*,
+};
 use noise::{HybridMulti, NoiseFn, Perlin};
 
 const PATROL_RANGE: f32 = 180.0;
@@ -81,8 +86,8 @@ impl VoxelWorldConfig for MainWorld {
         // directly set lod values to our stride lengths
         if distance > 4.0 {
             return 4;
-        } 
-        
+        }
+
         1
     }
 }
@@ -92,6 +97,9 @@ struct PatrolCamera {
     target: Vec3,
     speed: f32,
 }
+
+#[derive(Component)]
+struct CameraCountText;
 
 #[derive(Resource, Clone)]
 struct PatrolMarkerAssets {
@@ -104,7 +112,14 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugins(VoxelWorldPlugin::with_config(MainWorld))
         .add_systems(Startup, setup)
-        .add_systems(Update, (patrol_cameras, add_patrol_camera))
+        .add_systems(
+            Update,
+            (
+                patrol_cameras,
+                update_patrol_camera_count,
+                update_camera_count_text,
+            ),
+        )
         .run();
 }
 
@@ -112,6 +127,7 @@ fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
+    mut fonts: ResMut<Assets<Font>>,
 ) {
     commands.insert_resource(ClearColor(Color::srgb(0.04, 0.06, 0.08)));
 
@@ -134,6 +150,32 @@ fn setup(
         Camera3d::default(),
         Transform::from_xyz(0.0, 300.0, 260.0)
             .looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
+    ));
+
+    commands.spawn((
+        Camera2d,
+        Camera {
+            order: 1,
+            ..default()
+        },
+    ));
+
+    let font = fonts.add(Font::try_from_bytes(DEFAULT_FONT_DATA.to_vec()).unwrap());
+    commands.spawn((
+        Text::new(camera_count_text(2)),
+        TextFont {
+            font,
+            font_size: 18.0,
+            ..default()
+        },
+        TextColor(Color::WHITE),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
+            ..default()
+        },
+        CameraCountText,
     ));
 
     let cascade_shadow_config = CascadeShadowConfigBuilder {
@@ -185,14 +227,28 @@ fn spawn_patrol_camera(
     ));
 }
 
-fn add_patrol_camera(
+fn update_patrol_camera_count(
     keys: Res<ButtonInput<KeyCode>>,
     mut commands: Commands,
     marker_assets: Res<PatrolMarkerAssets>,
-    patrols: Query<(), With<PatrolCamera>>,
+    patrols: Query<Entity, With<PatrolCamera>>,
 ) {
-    if keys.just_pressed(KeyCode::Space) {
+    if keys.just_pressed(KeyCode::Space)
+        || keys.just_pressed(KeyCode::Equal)
+        || keys.just_pressed(KeyCode::NumpadAdd)
+    {
         spawn_patrol_camera(&mut commands, &marker_assets, patrols.iter().count());
+    }
+
+    if keys.just_pressed(KeyCode::Backspace)
+        || keys.just_pressed(KeyCode::Minus)
+        || keys.just_pressed(KeyCode::NumpadSubtract)
+    {
+        if patrols.iter().count() > 1 {
+            if let Some(entity) = patrols.iter().last() {
+                commands.entity(entity).despawn();
+            }
+        }
     }
 }
 
@@ -210,10 +266,30 @@ fn patrol_cameras(
             continue;
         }
 
+        let travel_direction = to_target.normalize_or_zero();
         let step = (patrol.speed * time.delta_secs()).min(distance);
         transform.translation += to_target.normalize_or_zero() * step;
         transform.look_at(patrol.target, Vec3::Y);
     }
+}
+
+fn update_camera_count_text(
+    patrols: Query<(), With<PatrolCamera>>,
+    mut text_query: Query<&mut Text, With<CameraCountText>>,
+) {
+    let Some(mut text) = text_query.iter_mut().next() else {
+        return;
+    };
+
+    text.0 = camera_count_text(patrols.iter().count());
+}
+
+fn camera_count_text(count: usize) -> String {
+    format!(
+        "VoxelWorldCameras: {count}\n\
+        Space / +: Add patrol camera\n\
+        Backspace / -: Remove patrol camera"
+    )
 }
 
 fn random_patrol_point() -> Vec3 {

--- a/examples/multiple_cameras.rs
+++ b/examples/multiple_cameras.rs
@@ -240,15 +240,13 @@ fn update_patrol_camera_count(
         spawn_patrol_camera(&mut commands, &marker_assets, patrols.iter().count());
     }
 
-    if keys.just_pressed(KeyCode::Backspace)
+    let remove_requested = keys.just_pressed(KeyCode::Backspace)
         || keys.just_pressed(KeyCode::Minus)
-        || keys.just_pressed(KeyCode::NumpadSubtract)
-    {
-        if patrols.iter().count() > 1 {
-            if let Some(entity) = patrols.iter().last() {
-                commands.entity(entity).despawn();
-            }
-        }
+        || keys.just_pressed(KeyCode::NumpadSubtract);
+
+    if remove_requested && patrols.iter().count() > 1 {
+        let entity = patrols.iter().last().expect("at least one patrol camera");
+        commands.entity(entity).despawn();
     }
 }
 
@@ -266,7 +264,6 @@ fn patrol_cameras(
             continue;
         }
 
-        let travel_direction = to_target.normalize_or_zero();
         let step = (patrol.speed * time.delta_secs()).min(distance);
         transform.translation += to_target.normalize_or_zero() * step;
         transform.look_at(patrol.target, Vec3::Y);

--- a/examples/multiple_cameras.rs
+++ b/examples/multiple_cameras.rs
@@ -1,0 +1,271 @@
+use std::sync::Arc;
+
+use bevy::{
+    color::palettes::css::{AQUA, FUCHSIA, LIME, ORANGE, YELLOW},
+    light::CascadeShadowConfigBuilder,
+    platform::collections::HashMap,
+    prelude::*,
+};
+use bevy_voxel_world::{custom_meshing::{CHUNK_SIZE_F, CHUNK_SIZE_U}, prelude::*};
+use noise::{HybridMulti, NoiseFn, Perlin};
+
+const PATROL_RANGE: f32 = 180.0;
+const PATROL_HEIGHT: f32 = 28.0;
+const TERRAIN_NOISE_SCALE: f64 = 4000.0;
+const TERRAIN_HEIGHT_SCALE: f64 = 20.0;
+
+#[derive(Resource, Clone, Default)]
+struct MainWorld;
+
+impl VoxelWorldConfig for MainWorld {
+    type MaterialIndex = u8;
+    type ChunkUserBundle = ();
+
+    fn spawning_distance(&self) -> u32 {
+        8
+    }
+
+    fn min_despawn_distance(&self) -> u32 {
+        1
+    }
+
+    fn chunk_spawn_strategy(&self) -> ChunkSpawnStrategy {
+        ChunkSpawnStrategy::CloseAndInView
+    }
+
+    fn chunk_despawn_strategy(&self) -> ChunkDespawnStrategy {
+        ChunkDespawnStrategy::FarAwayOrOutOfView
+    }
+
+    fn spawning_rays(&self) -> usize {
+        12
+    }
+
+    fn max_spawn_per_frame(&self) -> usize {
+        500
+    }
+
+    fn voxel_lookup_delegate(&self) -> VoxelLookupDelegate<Self::MaterialIndex> {
+        Box::new(move |_chunk_pos, _lod, _previous| get_voxel_fn())
+    }
+
+    fn texture_index_mapper(
+        &self,
+    ) -> Arc<dyn Fn(Self::MaterialIndex) -> [u32; 3] + Send + Sync> {
+        Arc::new(|mat| match mat {
+            0 => [0, 0, 0],
+            1 => [1, 1, 1],
+            2 => [2, 2, 2],
+            3 => [3, 3, 3],
+            _ => [0, 0, 0],
+        })
+    }
+
+    fn chunk_data_shape(&self, lod_level: LodLevel) -> UVec3 {
+        padded_chunk_shape_uniform(CHUNK_SIZE_U / lod_level.max(1) as u32)
+    }
+
+    fn chunk_meshing_shape(&self, lod_level: LodLevel) -> UVec3 {
+        padded_chunk_shape_uniform(CHUNK_SIZE_U / lod_level.max(1) as u32)
+    }
+
+    fn chunk_lod(
+        &self,
+        chunk_position: IVec3,
+        _previous_lod: Option<LodLevel>,
+        camera_position: Vec3,
+    ) -> LodLevel {
+        let camera_chunk = (camera_position / CHUNK_SIZE_F).floor();
+        let distance = chunk_position.as_vec3().distance(camera_chunk);
+
+        // directly set lod values to our stride lengths
+        if distance > 4.0 {
+            return 4;
+        } 
+        
+        1
+    }
+}
+
+#[derive(Component)]
+struct PatrolCamera {
+    target: Vec3,
+    speed: f32,
+}
+
+#[derive(Resource, Clone)]
+struct PatrolMarkerAssets {
+    mesh: Handle<Mesh>,
+    materials: Vec<Handle<StandardMaterial>>,
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(VoxelWorldPlugin::with_config(MainWorld))
+        .add_systems(Startup, setup)
+        .add_systems(Update, (patrol_cameras, add_patrol_camera))
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    commands.insert_resource(ClearColor(Color::srgb(0.04, 0.06, 0.08)));
+
+    let marker_assets = PatrolMarkerAssets {
+        mesh: meshes.add(Sphere { radius: 4.0 }),
+        materials: vec![
+            materials.add(Color::from(AQUA)),
+            materials.add(Color::from(FUCHSIA)),
+            materials.add(Color::from(LIME)),
+            materials.add(Color::from(ORANGE)),
+            materials.add(Color::from(YELLOW)),
+        ],
+    };
+
+    spawn_patrol_camera(&mut commands, &marker_assets, 0);
+    spawn_patrol_camera(&mut commands, &marker_assets, 1);
+    commands.insert_resource(marker_assets);
+
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0.0, 300.0, 260.0)
+            .looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
+    ));
+
+    let cascade_shadow_config = CascadeShadowConfigBuilder {
+        maximum_distance: 650.0,
+        ..default()
+    }
+    .build();
+    commands.spawn((
+        DirectionalLight {
+            color: Color::srgb(0.98, 0.95, 0.82),
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::from_xyz(0.0, 0.0, 0.0)
+            .looking_at(Vec3::new(-0.2, -0.35, 0.15), Vec3::Y),
+        cascade_shadow_config,
+    ));
+
+    commands.insert_resource(GlobalAmbientLight {
+        color: Color::srgb(0.98, 0.95, 0.82),
+        brightness: 90.0,
+        affects_lightmapped_meshes: true,
+    });
+}
+
+fn spawn_patrol_camera(
+    commands: &mut Commands,
+    marker_assets: &PatrolMarkerAssets,
+    index: usize,
+) {
+    let start = random_patrol_point();
+    let target = random_patrol_point();
+    let material = marker_assets.materials[index % marker_assets.materials.len()].clone();
+
+    commands.spawn((
+        Camera3d::default(),
+        Camera {
+            is_active: false,
+            ..default()
+        },
+        Mesh3d(marker_assets.mesh.clone()),
+        MeshMaterial3d(material),
+        Transform::from_translation(start).looking_at(target, Vec3::Y),
+        PatrolCamera {
+            target,
+            speed: rand::random_range(12.0..28.0),
+        },
+        VoxelWorldCamera::<MainWorld>::default(),
+    ));
+}
+
+fn add_patrol_camera(
+    keys: Res<ButtonInput<KeyCode>>,
+    mut commands: Commands,
+    marker_assets: Res<PatrolMarkerAssets>,
+    patrols: Query<(), With<PatrolCamera>>,
+) {
+    if keys.just_pressed(KeyCode::Space) {
+        spawn_patrol_camera(&mut commands, &marker_assets, patrols.iter().count());
+    }
+}
+
+fn patrol_cameras(
+    time: Res<Time>,
+    mut patrols: Query<(&mut Transform, &mut PatrolCamera)>,
+) {
+    for (mut transform, mut patrol) in patrols.iter_mut() {
+        let to_target = patrol.target - transform.translation;
+        let distance = to_target.length();
+
+        if distance < 4.0 {
+            patrol.target = random_patrol_point();
+            patrol.speed = rand::random_range(12.0..28.0);
+            continue;
+        }
+
+        let step = (patrol.speed * time.delta_secs()).min(distance);
+        transform.translation += to_target.normalize_or_zero() * step;
+        transform.look_at(patrol.target, Vec3::Y);
+    }
+}
+
+fn random_patrol_point() -> Vec3 {
+    let x = rand::random_range(-PATROL_RANGE..PATROL_RANGE);
+    let z = rand::random_range(-PATROL_RANGE..PATROL_RANGE);
+    Vec3::new(x, terrain_height(x, z) + PATROL_HEIGHT, z)
+}
+
+fn terrain_height(x: f32, z: f32) -> f32 {
+    let noise = terrain_noise();
+    (noise.get([
+        x as f64 / TERRAIN_NOISE_SCALE,
+        z as f64 / TERRAIN_NOISE_SCALE,
+    ]) * TERRAIN_HEIGHT_SCALE)
+        .max(0.0) as f32
+}
+
+fn terrain_noise() -> HybridMulti<Perlin> {
+    let mut noise = HybridMulti::<Perlin>::new(1234);
+    noise.octaves = 5;
+    noise.frequency = 1.1;
+    noise.lacunarity = 2.8;
+    noise.persistence = 0.4;
+    noise
+}
+
+fn get_voxel_fn() -> Box<dyn FnMut(IVec3, Option<WorldVoxel>) -> WorldVoxel + Send + Sync>
+{
+    let noise = terrain_noise();
+    let mut cache = HashMap::<(i32, i32), f64>::new();
+
+    Box::new(move |pos: IVec3, _previous| {
+        if pos.y < 0 {
+            return WorldVoxel::Solid(3);
+        }
+
+        let [x, y, z] = pos.as_dvec3().to_array();
+        let is_ground = y < match cache.get(&(pos.x, pos.z)) {
+            Some(sample) => *sample,
+            None => {
+                let sample = noise
+                    .get([x / TERRAIN_NOISE_SCALE, z / TERRAIN_NOISE_SCALE])
+                    * TERRAIN_HEIGHT_SCALE;
+                cache.insert((pos.x, pos.z), sample);
+                sample
+            }
+        };
+
+        if is_ground {
+            WorldVoxel::Solid(0)
+        } else {
+            WorldVoxel::Air
+        }
+    })
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
-use crate::chunk_map::{ChunkMapInsertBuffer, ChunkMapUpdateBuffer};
+use crate::chunk_map::{ChunkMap, ChunkMapInsertBuffer, ChunkMapUpdateBuffer};
 use crate::configuration::VoxelWorldConfig;
 use crate::mesh_cache::MeshCacheInsertBuffer;
 use crate::meshing::generate_chunk_mesh_for_shape;
@@ -33,6 +33,48 @@ fn _test_setup_app() -> App {
     });
 
     app
+}
+
+#[test]
+fn chunks_spawn_with_multiple_voxel_world_cameras() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, VoxelWorldPlugin::<DefaultWorld>::minimal()));
+    app.add_systems(Startup, |mut commands: Commands| {
+        let first_transform =
+            Transform::from_xyz(10.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y);
+        commands.spawn((
+            Camera::default(),
+            Camera3d::default(),
+            first_transform,
+            GlobalTransform::from(first_transform),
+            VoxelWorldCamera::<DefaultWorld>::default(),
+        ));
+
+        let second_transform =
+            Transform::from_xyz(1000.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y);
+        commands.spawn((
+            Camera::default(),
+            Camera3d::default(),
+            second_transform,
+            GlobalTransform::from(second_transform),
+            VoxelWorldCamera::<DefaultWorld>::default(),
+        ));
+    });
+
+    app.update();
+
+    type Mat = <DefaultWorld as VoxelWorldConfig>::MaterialIndex;
+    let chunk_map = app.world().resource::<ChunkMap<DefaultWorld, Mat>>();
+    let chunk_map_read_lock = chunk_map.get_read_lock();
+
+    assert!(ChunkMap::<DefaultWorld, Mat>::contains_chunk(
+        &IVec3::ZERO,
+        &chunk_map_read_lock,
+    ));
+    assert!(ChunkMap::<DefaultWorld, Mat>::contains_chunk(
+        &(IVec3::new(1000, 10, 10) / CHUNK_SIZE_I),
+        &chunk_map_read_lock,
+    ));
 }
 
 #[test]

--- a/src/voxel_world.rs
+++ b/src/voxel_world.rs
@@ -16,7 +16,7 @@ use crate::{
     voxel_world_internal::{ModifiedVoxels, VoxelWriteBuffer},
 };
 
-/// This component is used to mark the Camera that bevy_voxel_world should use to determine
+/// This component is used to mark Cameras that bevy_voxel_world should use to determine
 /// which chunks to spawn and despawn.
 #[derive(Component)]
 pub struct VoxelWorldCamera<C> {

--- a/src/voxel_world_internal.rs
+++ b/src/voxel_world_internal.rs
@@ -107,17 +107,18 @@ where
         let world_root = world_root.single().unwrap();
         let attach_to_root = configuration.attach_chunks_to_root();
 
-        let Ok((camera, cam_gtf)) = camera_info.single() else {
+        let cameras: Vec<_> = camera_info
+            .iter()
+            .map(|(camera, transform)| TrackedCamera::new(camera, transform))
+            .collect();
+        if cameras.is_empty() {
             return;
-        };
-        let camera_position = cam_gtf.translation();
-        let cam_pos = camera_position.as_ivec3();
+        }
 
         let spawning_distance = configuration.spawning_distance() as i32;
         let spawning_distance_squared = spawning_distance.pow(2);
         let spawn_strategy = configuration.chunk_spawn_strategy();
 
-        let viewport_size = camera.physical_viewport_size().unwrap_or_default();
         let visibility_margin = 0.0f32;
         let protected_chunk_radius_sq =
             (configuration.min_despawn_distance() as i32).pow(2);
@@ -131,8 +132,9 @@ where
 
         // Shoots a ray from the given point, and queue all (non-spawned) chunks intersecting the ray
         let queue_chunks_intersecting_ray_from_point =
-            |point: Vec2, queue: &mut VecDeque<IVec3>| {
-                let Ok(ray) = camera.viewport_to_world(cam_gtf, point) else {
+            |camera: &TrackedCamera, point: Vec2, queue: &mut VecDeque<IVec3>| {
+                let Ok(ray) = camera.camera.viewport_to_world(camera.transform, point)
+                else {
                     return;
                 };
                 let mut current = ray.origin;
@@ -158,6 +160,9 @@ where
         // Each frame we pick some random points on the screen
         let m = configuration.spawning_ray_margin();
         for _ in 0..configuration.spawning_rays() {
+            let camera = &cameras[rand::random_range(0..cameras.len())];
+            let viewport_size =
+                camera.camera.physical_viewport_size().unwrap_or_default();
             let random_point_in_viewport = {
                 let x =
                     rand::random::<f32>() * (viewport_size.x + m * 2) as f32 - m as f32;
@@ -168,19 +173,21 @@ where
 
             // Then, for each point, we cast a ray, picking up any unspawned chunks along the ray
             queue_chunks_intersecting_ray_from_point(
+                camera,
                 random_point_in_viewport,
                 &mut chunks_deque,
             );
         }
 
-        // We also queue the chunks closest to the camera to make sure they will always spawn early
-        let chunk_at_camera = cam_pos / CHUNK_SIZE_I;
-        let distance = configuration.min_despawn_distance() as i32;
-        for x in -distance..=distance {
-            for y in -distance..=distance {
-                for z in -distance..=distance {
-                    let queue_pos = chunk_at_camera + IVec3::new(x, y, z);
-                    chunks_deque.push_back(queue_pos);
+        // We also queue the chunks closest to every camera to make sure they will always spawn early.
+        let protected_distance = configuration.min_despawn_distance() as i32;
+        for camera in &cameras {
+            for x in -protected_distance..=protected_distance {
+                for y in -protected_distance..=protected_distance {
+                    for z in -protected_distance..=protected_distance {
+                        let queue_pos = camera.chunk_position + IVec3::new(x, y, z);
+                        chunks_deque.push_back(queue_pos);
+                    }
                 }
             }
         }
@@ -194,21 +201,25 @@ where
             }
             visited.insert(chunk_position);
 
-            if chunk_position.distance_squared(chunk_at_camera)
-                > spawning_distance_squared
-            {
+            if !chunk_is_close_to_any_camera(
+                &cameras,
+                chunk_position,
+                spawning_distance_squared,
+            ) {
                 continue;
             }
 
             if spawn_strategy == ChunkSpawnStrategy::CloseAndInView
-                && !chunk_visible_to_camera(
-                    camera,
-                    cam_gtf,
+                && !chunk_visible_to_any_camera(
+                    &cameras,
                     chunk_position,
                     visibility_margin,
                 )
-                && chunk_position.distance_squared(chunk_at_camera)
-                    > protected_chunk_radius_sq
+                && !chunk_is_close_to_any_camera(
+                    &cameras,
+                    chunk_position,
+                    protected_chunk_radius_sq,
+                )
             {
                 continue;
             }
@@ -223,6 +234,8 @@ where
                 if attach_to_root {
                     commands.entity(world_root).add_child(chunk_entity);
                 }
+                let camera_position =
+                    closest_camera_position_to_chunk(&cameras, chunk_position);
                 let lod_level =
                     configuration.chunk_lod(chunk_position, None, camera_position);
                 let data_shape = configuration.chunk_data_shape(lod_level);
@@ -278,13 +291,17 @@ where
         camera_info: CameraInfo<C>,
         mut ev_chunk_will_change_lod: MessageWriter<ChunkWillChangeLod<C>>,
     ) {
-        let Ok((_, cam_gtf)) = camera_info.single() else {
+        let cameras: Vec<_> = camera_info
+            .iter()
+            .map(|(camera, transform)| TrackedCamera::new(camera, transform))
+            .collect();
+        if cameras.is_empty() {
             return;
-        };
-
-        let camera_position = cam_gtf.translation();
+        }
 
         for (entity, mut chunk) in chunks.iter_mut() {
+            let camera_position =
+                closest_camera_position_to_chunk(&cameras, chunk.position);
             let target_lod = configuration.chunk_lod(
                 chunk.position,
                 Some(chunk.lod_level),
@@ -328,10 +345,13 @@ where
         let spawning_distance = configuration.spawning_distance() as i32;
         let spawning_distance_squared = spawning_distance.pow(2);
 
-        let (camera, cam_gtf) = camera_info.single().unwrap();
-        let cam_pos = cam_gtf.translation().as_ivec3();
-
-        let chunk_at_camera = cam_pos / CHUNK_SIZE_I;
+        let cameras: Vec<_> = camera_info
+            .iter()
+            .map(|(camera, transform)| TrackedCamera::new(camera, transform))
+            .collect();
+        if cameras.is_empty() {
+            return;
+        }
 
         let chunks_to_remove = {
             let mut remove = Vec::with_capacity(1000);
@@ -340,9 +360,8 @@ where
                     match configuration.chunk_despawn_strategy() {
                         ChunkDespawnStrategy::FarAway => false,
                         ChunkDespawnStrategy::FarAwayOrOutOfView => {
-                            let frustum_culled = !chunk_visible_to_camera(
-                                camera,
-                                cam_gtf,
+                            let frustum_culled = !chunk_visible_to_any_camera(
+                                &cameras,
                                 chunk.position,
                                 0.0,
                             );
@@ -354,12 +373,17 @@ where
                         }
                     }
                 };
-                let dist_squared = chunk.position.distance_squared(chunk_at_camera);
-                let near_camera = dist_squared
-                    <= (CHUNK_SIZE_I * configuration.min_despawn_distance() as i32)
-                        .pow(2);
+                let near_camera = chunk_is_close_to_any_camera(
+                    &cameras,
+                    chunk.position,
+                    (CHUNK_SIZE_I * configuration.min_despawn_distance() as i32).pow(2),
+                );
                 if (should_be_culled && !near_camera)
-                    || dist_squared > spawning_distance_squared + 1
+                    || !chunk_is_close_to_any_camera(
+                        &cameras,
+                        chunk.position,
+                        spawning_distance_squared + 1,
+                    )
                 {
                     remove.push(chunk);
                 }
@@ -678,6 +702,66 @@ where
                 .remove::<NeedsMaterial<C>>();
         }
     }
+}
+
+struct TrackedCamera<'a> {
+    camera: &'a Camera,
+    transform: &'a GlobalTransform,
+    position: Vec3,
+    chunk_position: IVec3,
+}
+
+impl<'a> TrackedCamera<'a> {
+    fn new(camera: &'a Camera, transform: &'a GlobalTransform) -> Self {
+        let position = transform.translation();
+        Self {
+            camera,
+            transform,
+            position,
+            chunk_position: position.as_ivec3() / CHUNK_SIZE_I,
+        }
+    }
+}
+
+fn chunk_is_close_to_any_camera(
+    cameras: &[TrackedCamera],
+    chunk_position: IVec3,
+    distance_squared: i32,
+) -> bool {
+    cameras.iter().any(|camera| {
+        chunk_position.distance_squared(camera.chunk_position) <= distance_squared
+    })
+}
+
+fn closest_camera_position_to_chunk(
+    cameras: &[TrackedCamera],
+    chunk_position: IVec3,
+) -> Vec3 {
+    let chunk_world_position = chunk_position.as_vec3() * CHUNK_SIZE_F;
+    cameras
+        .iter()
+        .min_by(|a, b| {
+            a.position
+                .distance_squared(chunk_world_position)
+                .total_cmp(&b.position.distance_squared(chunk_world_position))
+        })
+        .map(|camera| camera.position)
+        .unwrap_or(Vec3::ZERO)
+}
+
+fn chunk_visible_to_any_camera(
+    cameras: &[TrackedCamera],
+    chunk_position: IVec3,
+    ndc_margin: f32,
+) -> bool {
+    cameras.iter().any(|camera| {
+        chunk_visible_to_camera(
+            camera.camera,
+            camera.transform,
+            chunk_position,
+            ndc_margin,
+        )
+    })
 }
 
 fn chunk_visible_to_camera(


### PR DESCRIPTION
This PR adds the ability to have more than one VoxelWorldCamera per voxel world. Spawning, LOD and despawning take all cameras into account.

<img width="1290" height="756" alt="Screenshot 2025-06-12 at 11 10 02 PM" src="https://github.com/user-attachments/assets/f4ba497f-a707-4549-aad0-899077e3d0ff" />

I'm doing some "non-standard" stuff with this engine in my game (pictured above). To accomplish this trick up until now I've been rendering two worlds at once but this PR would let me merge it down to just one world and eliminate a lot of overhead.

I'm upstreaming this because I think it would have utility beyond my needs such as multiplayer. The new included example hints towards this.